### PR TITLE
Add support for Line marks

### DIFF
--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -1,6 +1,6 @@
 import { BindingEdge, GraphManager, BindingGraph, BindingNode } from "./GraphManager";
 import { BindingManager, VirtualBindingEdge, } from "./BindingManager";
-import { compilationContext, deduplicateById, validateComponent, removeUndefinedInSpec, logComponentInfo, detectAndMergeSuperNodes, resolveAnchorValue } from "./binding";
+import { compilationContext, deduplicateById, validateComponent, removeUndefinedInSpec, logComponentInfo, detectAndMergeSuperNodes, resolveAnchorValue, removeUnreferencedParams } from "./binding";
 import { AnchorProxy, SchemaType, SchemaValue, RangeValue, SetValue, ScalarValue } from "../types/anchors";
 import { BaseComponent } from "../components/base";
 import { TopLevelSpec, UnitSpec } from "vega-lite/build/src/spec";
@@ -12,6 +12,7 @@ import { extractConstraintsForMergedComponent, VGX_MERGED_SIGNAL_NAME } from "./
 // import { resolveCycles } from "./cycles";
 import { resolveCycleMulti, expandEdges, extractChannel, isCompatible } from "./cycles_CLEAN";
 import { pruneEdges } from "./prune";
+import { Spec } from "vega-typings";
 interface AnchorEdge {
     originalEdge: BindingEdge;
     anchorProxy: AnchorProxy;
@@ -41,7 +42,6 @@ function generateScalarConstraints(schema: SchemaType, value: SchemaValue): stri
 
 // 
 function generateRangeConstraints(schema: SchemaType, value: SchemaValue): string {
-    console.log('generating range constraints for', schema, value)
     if (schema.container === 'Range') {
         //TODO SOMETHING WEIRD IS HAPPIGN HERE WHERE RECT IS GIVING WEIRD UPDATES TO THIS
         value = value as RangeValue
@@ -84,13 +84,10 @@ export class SpecCompiler {
 
         const prunedEdges = pruneEdges(rootComponent.id, expandedEdges);
 
-        console.log('prunedEdges::', prunedEdges)
         
         bindingGraph.edges = prunedEdges;
-        console.log('addedimplicitEdges', bindingGraph)
    
         const processedGraph = resolveCycleMulti(bindingGraph, this.getBindingManager());
-        console.log('processedGraph!!!', processedGraph)
 
 
         // Compile the updated graph
@@ -100,47 +97,9 @@ export class SpecCompiler {
 
         //TODO stop from removing undefined with data
         const undefinedRemoved = removeUndefinedInSpec(mergedSpec);
-        
-        // Stringify the spec (omitting data) to search for parameter usage
-        const specString = JSON.stringify(undefinedRemoved, (key, value) => {
-            // Skip data values to reduce size
-            if (key === 'values' && Array.isArray(value)) {
-                return '[...]';
-            }
-            return value;
-        });
-        
-        // Check if each parameter is actually used in expressions
-        const usedParams = undefinedRemoved.params?.filter(param => {
-            const paramName = param.name;
-            // Look for the parameter name within expression strings
-            // Match both 'paramName' and "paramName" patterns
-            const singleQuotePattern = `'${paramName}'`;
-            const doubleQuotePattern = `"${paramName}"`;
-            // Also match direct references to the parameter in expressions
-            const directRefPattern = new RegExp(`\\b${paramName}\\b`);
-            
-            // Count occurrences to ensure parameter is used at least twice
-            const singleQuoteMatches = (specString.match(new RegExp(singleQuotePattern, 'g')) || []).length;
-            const doubleQuoteMatches = (specString.match(new RegExp(doubleQuotePattern, 'g')) || []).length;
-            // const directRefMatches = (specString.match(directRefPattern) || []).length;
-            
-            const totalOccurrences = singleQuoteMatches + doubleQuoteMatches;// + directRefMatches;
-            console.log('totalOccurrences', paramName, totalOccurrences)
-            console.log('matches',specString.match(new RegExp(singleQuotePattern, 'g')),specString.match(new RegExp(doubleQuotePattern, 'g')),specString.match(directRefPattern))
-            return totalOccurrences >= 2;
-        }) || [];
-        console.log('usedParams', usedParams,undefinedRemoved.params)
-        
-        // Update the spec with only the parameters that are actually used
-        undefinedRemoved.params = usedParams;
-        
-        console.log('undefinedRemoved', undefinedRemoved);
-        
+        const unreferencedRemoved = removeUnreferencedParams(undefinedRemoved);
 
-        // IDK why this is needed, but something is deeply wrong with Vega signals and apparently param order matters
-        // Sort params and move nodes ending with _start to the end
-        const sortedParams = undefinedRemoved.params?.sort((a, b) => {
+        const sortedParams = unreferencedRemoved.params?.sort((a, b) => {
             const aEndsWithStart = a.name.endsWith('span_start_x') || a.name.endsWith('span_start_y');
             const bEndsWithStart = b.name.endsWith('span_start_x') || b.name.endsWith('span_start_y');
             
@@ -157,7 +116,6 @@ export class SpecCompiler {
 
     private buildImplicitContextEdges(node: BindingNode, edges: BindingEdge[], nodes: BindingNode[]): Record<string, Constraint[]> {
         const constraints: Record<string, Constraint[]> = {};
-        console.log('building implicit context edges for', node, edges, nodes);
 
         // Skip if this is a merged node
         if (node.type === 'merged') {
@@ -169,7 +127,6 @@ export class SpecCompiler {
             edges.some(edge => edge.source.nodeId === n.id && edge.target.nodeId === node.id)
         );
         
-        console.log('parent nodes:', parentNodes);
         
         if (parentNodes.length === 0) return constraints;
         
@@ -192,7 +149,6 @@ export class SpecCompiler {
             const defaultConfigKey = Object.keys(parentComponent.configurations || {})
                 .find(cfg => parentComponent.configurations[cfg]?.default);
 
-            console.log('defaultConfigKey', defaultConfigKey, parentComponent)
             
             if (!defaultConfigKey) continue;
             
@@ -225,7 +181,6 @@ export class SpecCompiler {
             // Find compatible target anchor on current node
             const targetAnchors = component.getAnchors()
                 .filter(anchor => {
-                    console.log('idIMPLOICIT', anchor.id.anchorId, )
                     const targetChannel = extractChannel(anchor.id.anchorId);
                     return targetChannel && isCompatible(channel, targetChannel);
                 });
@@ -244,9 +199,7 @@ export class SpecCompiler {
                 },
                 implicit: true
             };
-            
-            console.log('Created implicit edge:', implicitEdge);
-            
+                        
             // Add to implicit edges
             edges.push(implicitEdge);
         }
@@ -265,7 +218,6 @@ export class SpecCompiler {
      */
     private compileBindingGraph(rootId: string, bindingGraph: BindingGraph): Partial<UnitSpec<Field>>[] {
         const { nodes, edges } = bindingGraph;
-        console.log('FINALedges', edges)
         const visitedNodes = new Set<string>();
         const constraintsByNode: Record<string, Record<string, any[]>> = {};
         const mergedNodeIds = new Set<string>();
@@ -308,7 +260,6 @@ export class SpecCompiler {
             
             // Store constraints for later use by merged nodes
             constraintsByNode[nodeId] = constraints;
-            console.log('constraintsByNode', constraintsByNode)
             // Compile the current component
             const compiledNode = component.compileComponent(constraints);
 
@@ -345,7 +296,6 @@ export class SpecCompiler {
                 return { anchor, targetId: edge.target.anchorId };
             }).filter((anchor): anchor is { anchor: AnchorProxy, targetId: string } => anchor !== undefined);
 
-            // console.log('parentAnchors:::', parentAnchors, JSON.parse(JSON.stringify(compileConstraints)), component)
             // Extract constraints for merged component
             const mergedSignals = extractConstraintsForMergedComponent(parentAnchors, constraintsByNode, component);
             const constraints: Record<AnchorId, Constraint[]> = {
@@ -378,20 +328,17 @@ export class SpecCompiler {
         const anchorAccessor = anchorProxy.compile();
         // Handle special case for absolute values
         if ('absoluteValue' in anchorAccessor) {
-            console.log('adding absolute value constraint for', anchorAccessor.absoluteValue)
             constraints[targetAnchorId] = [anchorAccessor.absoluteValue];
             return;
         }
 
         // Add constraints based on container type
         if (currentNodeSchema.container === "Scalar") {
-            console.log('adding constraint for2', targetAnchorId, parentNodeSchema, anchorAccessor,generateScalarConstraints(parentNodeSchema, anchorAccessor))
 
             constraints[targetAnchorId].push(
                 generateScalarConstraints(parentNodeSchema, anchorAccessor)
             );
         } else if (currentNodeSchema.container === "Range") {
-            console.log('adding constraint for', parentNodeSchema, anchorAccessor,generateRangeConstraints(parentNodeSchema, anchorAccessor))
             constraints[targetAnchorId].push(
                 generateRangeConstraints(parentNodeSchema, anchorAccessor)
             );
@@ -433,7 +380,6 @@ export class SpecCompiler {
 
             const currentNodeSchema = component.schema[cleanTargetId]
             const parentNodeSchema = anchorProxy.anchorSchema[parentEdge.source.anchorId];
-            console.log('aprentNodeSchema', parentNodeSchema)
             
             // Skip if no schema exists for this channel
             if (!currentNodeSchema) continue;
@@ -443,7 +389,6 @@ export class SpecCompiler {
                 constraints[targetAnchorId] = [];
             }
             
-            console.log('adding constraint for', component, targetAnchorId, anchorProxy,anchorProxy.compile(), JSON.parse(JSON.stringify(constraints)))
             // Add appropriate constraint based on component schema type
             this.addConstraintForChannel(
                 constraints,
@@ -454,7 +399,6 @@ export class SpecCompiler {
             );
         }
 
-        console.log('final constraints', constraints)
         return constraints;
     }
 

--- a/src/binding/cycles_CLEAN.ts
+++ b/src/binding/cycles_CLEAN.ts
@@ -32,7 +32,7 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
             return [...component.getAnchors().values()].map(a => a.id.anchorId);
         }
 
-
+        console.log('expanding group anchors for', component.id, anchorId, component,component.configurations)
         if(component.configurations[anchorId]) {
 
             const componentAnchors = [...component.getAnchors().values()]
@@ -198,6 +198,7 @@ function rewireMultiNodeConnections(
 
         const channel = extractChannel(anchorId)
 
+
         if (!anchorId || !channel) {
             console.warn(`No anchor found for channel in component ${nodeId}`);
             return;
@@ -252,7 +253,7 @@ export function resolveCycleMulti(
     bindingManager: BindingManager
 ): BindingGraph {
     let processedGraph = cloneGraph(graph);
-    
+    console.log('processedGraphONR!!!', processedGraph)
     // Keep resolving cycles until none are left
     let cycles = detectCyclesByChannel(processedGraph.edges);
     let count = 10;
@@ -600,7 +601,7 @@ function cloneGraph(graph: BindingGraph): BindingGraph {
             id: node.id,
             type: node.type
         })),
-        edges: JSON.parse(JSON.stringify(graph.edges))
+        edges: JSON.parse(JSON.stringify(graph.edges)),
     };
 }
 

--- a/src/binding/cycles_CLEAN.ts
+++ b/src/binding/cycles_CLEAN.ts
@@ -32,7 +32,6 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
             return [...component.getAnchors().values()].map(a => a.id.anchorId);
         }
 
-        console.log('expanding group anchors for', component.id, anchorId, component,component.configurations)
         if(component.configurations[anchorId]) {
 
             const componentAnchors = [...component.getAnchors().values()]
@@ -204,10 +203,8 @@ function rewireMultiNodeConnections(
             return;
         }
 
-        console.log('creating internal anchor for', component.id, anchorId)
         // Create internal anchor
         createInternalAnchor(component, anchorId);
-        console.log('created internal anchor for2', component)
         
         // Redirect incoming edges to internal anchors
         redirectIncomingEdges(edges, nodeId, anchorId);
@@ -228,7 +225,6 @@ function rewireMultiNodeConnections(
             target: { nodeId, anchorId }
         });
 
-        console.log('pushed edges from ',nodeId, internalAnchorId, "to ", mergedNodeId, channel)
     });
     
     // Remove the original cycle edges
@@ -253,7 +249,6 @@ export function resolveCycleMulti(
     bindingManager: BindingManager
 ): BindingGraph {
     let processedGraph = cloneGraph(graph);
-    console.log('processedGraphONR!!!', processedGraph)
     // Keep resolving cycles until none are left
     let cycles = detectCyclesByChannel(processedGraph.edges);
     let count = 10;
@@ -565,7 +560,6 @@ function createInternalAnchor(component: BaseComponent, anchorId: string): void 
         return originalResult;
     };
 
-    console.log('about to set anchor', internalAnchorId, clonedAnchor)
     component.setAnchor(internalAnchorId, clonedAnchor);
 }
 

--- a/src/binding/mergedComponent_CLEAN.ts
+++ b/src/binding/mergedComponent_CLEAN.ts
@@ -287,12 +287,10 @@ export function extractConstraintsForMergedComponent(
 
     
       const parentSignalName = `${parentId}_${anchorFromParent.anchor.id.anchorId}_internal`
-      console.log('parentSignalName', parentSignalName)
      
       // Get all other components in the cycle
       const otherParentIds = parentComponentIds.filter(id => id !== parentId);
   
-      console.log('internalConstraints otherParentIds', otherParentIds)
       // Process constraints from each other parent
       const otherParentsConstraints = otherParentIds.map(otherParentId => {
         const otherParentConstraints = compileConstraints[otherParentId];
@@ -306,14 +304,11 @@ export function extractConstraintsForMergedComponent(
         const channel = component.getAnchors()[0]?.id.anchorId;
         if (!channel) return null;
 
-        console.log('internalConstraintsdassda',otherParentConstraints)
 
         const internalConstraints = Object.keys(otherParentConstraints).filter(key => key.endsWith('_internal')).filter(key=>isCompatible(key.replace('_internal', ''), channel))
 
-        console.log('internalConstraintsdassda2', internalConstraints)
         // if no interna constraints it means it didn't have any other constraints
         if(internalConstraints.length === 0) {
-            console.log('returning baseconstraint')
             return {
                 events: { "signal": parentSignalName },
                 update: parentSignalName
@@ -330,9 +325,7 @@ export function extractConstraintsForMergedComponent(
                 // I think has to deal with the merge constraints logic...
                 
                 const constraints = otherParentConstraints[internalKeys]
-                console.log('constraint COMPONTNETANCHOR', anchorFromParent.anchor.id.componentId)
                 return constraints.map(constraint => {
-                    console.log('in self reference?', constraint,constraint.includes(anchorFromParent.anchor.id.componentId))
                     if(constraint.includes('undefined') || constraint.includes(anchorFromParent.anchor.id.componentId)) return null;
                     return {
                         events: { "signal": parentSignalName },
@@ -342,16 +335,13 @@ export function extractConstraintsForMergedComponent(
              
             })
 
-        console.log("COMPILEDCONSTRAINTS1", constraints)
         return constraints.flat();
       }).filter(item => item !== null).flat();
 
-      console.log("COMPILEDCONSTRAINTS2", otherParentsConstraints)
   
       mergedSignals.push(...otherParentsConstraints);
     });
 
-    console.log("COMPILEDCONSTRAINTS3", mergedSignals)
   
     return mergedSignals;
   }

--- a/src/binding/prune.ts
+++ b/src/binding/prune.ts
@@ -1,0 +1,71 @@
+import { BindingEdge } from "./GraphManager";
+import { extractChannel, isCompatible } from "./cycles_CLEAN";
+/**
+ * Prunes edges that are not reachable from the root component.
+ * Returns both valid edges and implicit edges (pruned edges that might be needed later).
+ * 
+ * @param rootId The ID of the root component
+ * @param edges All binding edges in the graph
+ * @returns Object containing valid edges and implicit edges
+ */
+export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] {
+    // Start at the root id and determine which anchors are valid
+    const validEdges = new Set<BindingEdge>();
+    const visitedNodes = new Set<string>();
+
+    console.log('pruning beforeedges', edges)
+    
+    // Helper function to recursively validate edges
+    function validateEdgesForNode(nodeId: string, validChannels: Set<string>) {
+        if (visitedNodes.has(nodeId)) return;
+        visitedNodes.add(nodeId);
+        
+        // Find all edges where this node is the source
+        const outgoingEdges = edges.filter(edge => edge.source.nodeId === nodeId);
+        
+        for (const edge of outgoingEdges) {
+            const sourceChannel = extractChannel(edge.source.anchorId);
+            const targetChannel = extractChannel(edge.target.anchorId);
+            
+            // If the source channel is valid, this edge is valid
+            if (sourceChannel && validChannels.has(sourceChannel)) {
+                validEdges.add(edge);
+                
+                // The target node can now use this channel
+                const targetValidChannels = new Set(validChannels);
+                if (targetChannel) {
+                    targetValidChannels.add(targetChannel);
+                }
+                
+                // Recursively validate edges for the target node
+                validateEdgesForNode(edge.target.nodeId, targetValidChannels);
+            }
+        }
+    }
+    
+    // Start with the root node's channels
+    const rootChannels = new Set<string>();
+    
+    // Find all edges where root is the source to determine valid channels
+    edges.filter(edge => edge.source.nodeId === rootId).forEach(edge => {
+        const channel = extractChannel(edge.source.anchorId);
+        if (channel) rootChannels.add(channel);
+    });
+    
+    // Also include edges where root is the target
+    edges.filter(edge => edge.target.nodeId === rootId).forEach(edge => {
+        const channel = extractChannel(edge.target.anchorId);
+        if (channel) rootChannels.add(channel);
+    });
+    
+    // Start validation from the root
+    validateEdgesForNode(rootId, rootChannels);
+    
+    const prunedEdges = edges.filter(edge => validEdges.has(edge));
+    const implicitEdges = edges.filter(edge => !validEdges.has(edge));
+    
+    console.log('pruning afteredges', edges.length, 'to', prunedEdges.length, prunedEdges);
+    console.log('implicit edges', implicitEdges.length, implicitEdges);
+    
+    return prunedEdges;
+}

--- a/src/binding/prune.ts
+++ b/src/binding/prune.ts
@@ -13,7 +13,6 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
     const validEdges = new Set<BindingEdge>();
     const visitedNodes = new Set<string>();
 
-    console.log('pruning beforeedges', edges)
     
     // Helper function to recursively validate edges
     function validateEdgesForNode(nodeId: string, validChannels: Set<string>) {
@@ -64,8 +63,6 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
     const prunedEdges = edges.filter(edge => validEdges.has(edge));
     const implicitEdges = edges.filter(edge => !validEdges.has(edge));
     
-    console.log('pruning afteredges', edges.length, 'to', prunedEdges.length, prunedEdges);
-    console.log('implicit edges', implicitEdges.length, implicitEdges);
     
     return prunedEdges;
 }

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -57,7 +57,6 @@ export abstract class BaseComponent {
 
     bindings.forEach(({ value: binding, key }) => {
       const bindingProperty = key.startsWith('bind.') ? key.split('.')[1] : (key === 'bind' ? '_all' : key);
-      console.log('bindingProperty', bindingProperty)
 
       // TODO interactive binding reversal– this may be not needed depending on how scalar:scalar is handled
       if(bindingProperty === '_all'){
@@ -97,20 +96,8 @@ export abstract class BaseComponent {
         return 'span'
       }
 
-      // let configId = '';
-      //  if(bindingProperty.includes('bind')){
-      //   const split = bindingProperty.split('.')
-      //   const channel = split[0]
-      //   configId = split[1]
-      //   console.log('bindingProperty', bindingProperty, channel, configId)
-      //   // this.bindingManager.addBinding(this.id, , channel, configId);
-      // }
-      // console.log('configId', configId, 'binding',binding,'prop',bindingProperty)
-      // bindingProperty = configId;
-      
       // Check if this is a BaseChart by using instanceof or checking for chart-specific properties
       const isParentChart = ['Scatterplot','Histogram','BarChart'].includes(this.constructor.name);
-      console.log('isParentChart', isParentChart, this,this.constructor.name)
 
       if (isComponent(binding)) {
         this.bindingManager.addBinding(this.id, getTargetId(binding), bindingProperty, '_all');
@@ -120,7 +107,6 @@ export abstract class BaseComponent {
 
           const anchorSchema = Object.values(anchor.anchorSchema)[0];
           if(anchorSchema && anchorSchema.interactive && !isParentChart){ // TODO FIX such that chart isn't ddded...
-            console.log('dsadsaddads',this.id, this)
 
             this.bindingManager.addBinding(getTargetId(binding),this.id, anchor.id.anchorId, bindingProperty);
           }
@@ -130,7 +116,6 @@ export abstract class BaseComponent {
         // TODO: i think intertactiveity is not populating up and thus we don't get the inversee/internal stuff. 
         this.bindingManager.addBinding(this.id, getTargetId(binding), bindingProperty, binding.id.anchorId);
         if (binding.anchorSchema.interactive && !isParentChart) {
-          console.log('dsadsaddads2',this.id, this)
 
           this.bindingManager.addBinding(getTargetId(binding), this.id, binding.id.anchorId, binding.id.anchorId);
         }

--- a/src/components/charts/base.ts
+++ b/src/components/charts/base.ts
@@ -77,16 +77,10 @@ export class BaseChart extends BaseComponent {
 
   constructor(config: ChartConfig) {
     super({ ...config });
-    console.log('chart config', config)
     this.width = config.width || 400;
     this.height = config.height || 300;
     this.padding = config.padding || 20;
     this.configurations = this.generateChartConfigurations();
-    console.log('expanding group anchors for','now',this.configurations)
-
-
-
-
 
     this.spec = {
       name: this.id,
@@ -105,7 +99,6 @@ export class BaseChart extends BaseComponent {
   }
 
   private generateChartConfigurations() : Record<string, SchemaType> {
-    console.log('expanding group anchors for!')
 
 
     // Generate configurations for chart channels

--- a/src/components/interactions/drag2.ts
+++ b/src/components/interactions/drag2.ts
@@ -238,7 +238,6 @@ export class CombinedDrag extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }
@@ -253,7 +252,7 @@ export class CombinedDrag extends BaseComponent {
 
 
     }
-    
+
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {
         const nodeId = inputContext.nodeId || this.id;
         const signal = {
@@ -300,19 +299,15 @@ export class CombinedDrag extends BaseComponent {
                 );
             });
         // Additional signals can be added here and will be av  ilable in input contexts
-        console.log('this.anchors', [...this.anchors.keys()].filter(key => key.endsWith('_internal')))
         const internalSignals = [...this.anchors.keys()]
             .filter(key => key.endsWith('_internal'))
             .map(key => {
                 //no need to get constraints as constraints would have had it be already
                 // get the transform 
-                console.log('keys', key, key.split('_'), this.configurations)
                 const config = this.configurations[key.split('_')[0]];
-                console.log('generatedKEYSIGNAL', config, config.transforms)
 
                 const compatibleTransforms = config.transforms.filter(transform => transform.channel === key.split('_')[1])
 
-                console.log('compatibleTransformsDRAG', compatibleTransforms)
 
                 return compatibleTransforms.map(transform => generateSignal({
                     id: nodeId,
@@ -323,7 +318,6 @@ export class CombinedDrag extends BaseComponent {
             }
              
             ).flat();
-        console.log('DRAG outputSignals', outputSignals, internalSignals)
         return {
             params: [signal, ...outputSignals, ...internalSignals]
         }
@@ -429,7 +423,6 @@ export class Drag extends BaseComponent {
 export class DragSpan extends BaseComponent {
     constructor(config: any = {}) {
         super(config);
-        console.log('drag span config', config)
 
         this.schema = {
             'x': {

--- a/src/components/interactions/drag2.ts
+++ b/src/components/interactions/drag2.ts
@@ -253,6 +253,7 @@ export class CombinedDrag extends BaseComponent {
 
 
     }
+    
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {
         const nodeId = inputContext.nodeId || this.id;
         const signal = {

--- a/src/components/marks/circle.ts
+++ b/src/components/marks/circle.ts
@@ -172,11 +172,8 @@ export class Circle extends BaseComponent {
                 // get the transform 
                 const constraints = inputContext[key] || ["VGX_SIGNAL_NAME"];
                
-                console.log('keys', key, key.split('_'), this.configurations)
                 const config = this.configurations[key.split('_')[0]];
-                console.log('generatedKEYSIGNAL', config, config.transforms)
                 const compatibleTransforms = config.transforms.filter(transform => transform.channel === key.split('_')[1])
-                console.log('compatibleTransforms', compatibleTransforms)
                 return compatibleTransforms.map(transform => generateSignal({
                     id: nodeId,
                     transform: transform,

--- a/src/components/marks/index.ts
+++ b/src/components/marks/index.ts
@@ -1,5 +1,5 @@
 
 import { Circle } from './circle';
 import { Rect } from './rect';
-
-export { Circle, Rect };
+import { Line } from './line';
+export { Circle, Rect ,Line};

--- a/src/components/marks/line.ts
+++ b/src/components/marks/line.ts
@@ -1,0 +1,387 @@
+import { BaseComponent } from "../base";
+import { Field, isContinuousFieldOrDatumDef } from "vega-lite/build/src/channeldef";
+import { UnitSpec } from "vega-lite/build/src/spec";
+import { compilationContext } from '../../binding/binding';
+import { AnchorProxy, AnchorIdentifer, SchemaType } from "../../types/anchors";
+
+import { generateSignalFromAnchor, createRangeAccessor, generateCompiledValue, generateSignalsFromTransforms, generateSignal } from "../utils";
+import { extractSignalNames } from "../../binding/mergedComponent_CLEAN";
+
+const lineBaseContext = {
+    "x":{
+        start: 0,
+        stop: 1000
+       },
+       "y":{
+        start: 0,
+        stop: 1000
+       },
+    "color": "'red'",
+    "stroke": "'white'"
+}
+// Define the configurations with schemas and transforms
+const configurations = [{
+    'id': 'position',
+    "default": true,
+    "schema": {
+        "x": {
+            "container": "Range",
+            "valueType": "Numeric",
+            // "interactive": true
+        },
+        "y": {
+            "container": "Range",
+            "valueType": "Numeric",
+            // "interactive": true
+        }
+    },
+    "transforms": [
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.stop"}, //data set y value will be each y value.
+    ]
+},{
+    'id': 'x',
+    "default": true,
+    "schema": {
+        "x": {
+            "container": "Scalar",
+            "valueType": "Numeric",
+            // "interactive": true
+        },
+        "y": {
+            "container": "Range",
+            "valueType": "Numeric",
+            // "interactive": true
+        }
+    },
+    "transforms": [
+        { "name": "x", "channel": "x", "value": "PARENT_ID.x.start" },
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.stop"}, //data set y value will be each y value.
+    ]
+},{
+    'id': 'y',
+    "schema": {
+        "x": {
+            "container": "Range",
+            "valueType": "Numeric",
+            // "interactive": true
+        },
+        "y": {
+            "container": "Range",
+            "valueType": "Numeric",
+            // "interactive": true
+        }
+    },
+    "transforms": [
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" },
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.stop" },
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.start" },
+    ]
+}];
+
+
+
+import { generateConfigurationAnchors } from "../interactions/drag2";
+
+
+export class Line extends BaseComponent {
+    public schema: Record<string, SchemaType>;
+    public configurations: Record<string, any>;
+
+    constructor(config: any = {}) {
+        super({ ...config })
+
+        this.configurations = {};
+        configurations.forEach(cfg => {
+            this.configurations[cfg.id] = cfg;
+        });
+
+        // Set up the main schema from configurations
+        this.schema = {};
+       
+
+        configurations.forEach(config => {
+            this.configurations[config.id] = config
+            const schema = config.schema
+            for (const key in schema) {
+                const schemaValue = schema[key];
+                const keyName = config.id + '_' + key
+                this.schema[keyName] = schemaValue;
+
+
+                this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
+                    const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+                    return generatedAnchor
+                }));
+            }
+      
+        });
+
+        console.log('this.anchors.line', this.anchors)
+
+        // // Create anchors for each schema item
+        // Object.keys(this.schema).forEach(key => {
+        //     const schemaValue = schema[key];
+        //     const keyName = config.id + '_' + key
+        //     console.log('creating anchor for ', keyName)
+        //     console.log('setting schema', keyName, schemaValue)
+        //     this.schema[keyName] = schemaValue;
+        //     this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
+        //         const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+        //         console.log('generatedAnchor', generatedAnchor)
+        //         return generatedAnchor
+        //     }));
+        // });
+    }
+
+    compileComponent(inputContext: compilationContext): Partial<UnitSpec<Field>> {
+        const nodeId = inputContext.nodeId || this.id;
+
+
+        console.log('inputContextLINE', inputContext)
+
+        // // TODO handle missing key/anchors
+        // const outputSignals = Object.keys(this.schema).map(key =>
+        //     generateSignalFromAnchor(inputContext[key] || [], key, this.id, nodeId, this.schema[key].container)
+        // ).flat();
+
+        // Generate all signals from configurations
+        let generatedSignals = Object.values(this.configurations)
+            .filter(config => Array.isArray(config.transforms)) // Make sure transforms exist
+            .flatMap(config => {
+                // Build constraint map from inputContext
+                const constraintMap = {};
+                Object.keys(config.schema).forEach(channel => {
+                    const key = `${config.id}_${channel}`;
+                    constraintMap[channel] = inputContext[key] || inputContext[channel] || [];
+                });
+
+                const signalPrefix = this.id + '_' + config.id;
+
+                // Generate signals for this configuration
+                const generatedSignals = generateSignalsFromTransforms(
+                    config.transforms,
+                    nodeId,
+                    signalPrefix,
+                    constraintMap
+                );
+
+                console.log('generatedSignals', generatedSignals)
+                return generatedSignals.map(signal => {
+                    signal.expr= signal.on.find(on=>!!on.update)?.update
+                    console.log('signalEXPr', signal.expr)
+                    return signal
+                })
+            });
+
+            function removeEmptySignals(signals: any[]): any[] {
+                return signals.filter(signal => {
+                    console.log('signalUpdateCheck', signal, signal?.on, !signal?.on, signal.on?.length === 0);
+                    
+                    // If signal has no valid update mechanism (no expr, empty update, and no on events with updates)
+                    // then only keep it if it has a non-empty value
+                    if ((signal.expr === undefined || signal.expr === null || signal.expr === '') && 
+                        (signal.update === undefined || signal.update === null || signal.update === '') && 
+                        (!signal?.on || signal.on?.length === 0)) {
+                        return !(signal.value === undefined || signal.value === null || signal.value === '');
+                    }
+                    
+                    // Clean up empty update statements in 'on' array
+                    if (signal.on && Array.isArray(signal.on)) {
+                       
+                        signal.on = signal.on.filter((onItem: any) => 
+                            !(onItem.update === undefined || onItem.update === null || onItem.update === '')
+                        );
+                        if(signal.on?.length === 0){
+                            return false;
+                        }
+                    }
+                    
+                    return true;
+                });
+            }
+
+
+            let outputSignals = removeEmptySignals(generatedSignals)
+            console.log('outputSignalsREMOVED', outputSignals)
+
+            const [otherConfigurations, newOutputSignals] = fillInMissingContent(this.configurations, outputSignals)
+
+            console.log('otherConfigurations', otherConfigurations)
+            console.log('newOutputSignals', newOutputSignals)
+
+            outputSignals = newOutputSignals
+            console.log('changedOutput', outputSignals)
+
+
+
+
+/**
+ * Computes a default value based on schema container type and channel
+ * @param schema The schema definition (contains container type)
+ * @param transformName The name of the transform (e.g., x_start, y_stop)
+ * @param channel The channel name (e.g., x, y)
+ * @returns The appropriate default value
+ */
+function computeDefaultValue(schema, transformName, channel) {
+    // Default values based on container type
+    switch (schema.container) {
+        case 'Range':
+            // For ranges, use start/stop based on transform name
+            if (transformName.endsWith('_start')) {
+                return `range('${channel}')[1]`
+            } else if (transformName.endsWith('_stop')) {
+                return `range('${channel}')[0]`
+            }
+            return 0;
+            
+        case 'Scalar':
+            // For scalars, use direct value
+            if (channel === 'x' || channel === 'y') {
+                return `(range('${channel}')[0]+range('${channel}')[1])/2`;
+            } else if (channel === 'color' || channel === 'stroke') {
+                return "'red'"; // Default color as string expression
+            }
+            return 0;
+            
+        case 'Set':
+            // For sets, use first value or a reasonable default
+            const values = lineBaseContext[channel]?.values;
+            return values && values.length > 0 ? values[0] : 0;
+            
+        default:
+            // Fallback to base context or zero
+            return lineBaseContext[channel] || 0;
+    }
+}
+            /**
+ * Fills in missing values in configuration with defaults
+ * @param configuration The configuration object that may have missing values
+ * @param outputSignals The signals array that needs to be updated with defaults
+ * @returns An object with updated configuration and signals
+ */
+function fillInMissingContent(configuration: any, outputSignals: any) {
+    // Get the default configuration from your configurations array
+    const defaultConfig = configurations.find(cfg => cfg.default === true);
+    if (!defaultConfig) return { configuration, outputSignals };
+    
+    // For each schema item in the default configuration
+    Object.entries(defaultConfig.schema || {}).forEach(([channel, schemaValue]) => {
+        // Check if this channel is bound in the current configuration
+        const isBound = outputSignals.some((signal: any) => 
+            signal.name.includes(`_${defaultConfig.id}_${channel}`)
+        );
+        console.log('isBound', isBound, channel, `_${defaultConfig.id}_${channel}`);
+        
+        // If not bound, add default signals based on container type
+        if (!isBound) {
+            // Get transforms for this channel from the configuration
+            const relevantTransforms = defaultConfig.transforms.filter(transform => 
+                transform.channel === channel
+            );
+            
+            // For each transform that needs a default value
+            relevantTransforms.forEach(transform => {
+                const signalName = `${nodeId}_${defaultConfig.id}_${transform.name}`;
+                const defaultValue = computeDefaultValue(schemaValue, transform.name, channel);
+                console.log('relevanttransform', defaultConfig, transform, signalName, defaultValue);
+                
+                // Check if the signal exists
+                const existingSignalIndex = outputSignals.findIndex((s: any) => s.name === signalName);
+                console.log('existingSignalIndex', existingSignalIndex);
+                
+                if (existingSignalIndex >= 0) {
+                    // Update existing signal
+                    outputSignals[existingSignalIndex] = {
+                        name: signalName,
+                        expr: defaultValue
+                    };
+                } else {
+                    // Signal is missing entirely, create it
+                    outputSignals.push({
+                        name: signalName,
+                        expr: defaultValue
+                    });
+                }
+            });
+        }
+    });
+    
+    return [ configuration, outputSignals ];
+}
+
+        // function fillInMissingContent(configuration, outputSingals) {
+        //     // e.g. elaborate missing bits of information
+        //     // grab default configuration. 
+        //     // then for each schema value in it, if its not bound, change each of its corresponding signals to be the default value 
+        //     // create a function that computes the default value based on the container type. 
+        //     // return the updated configuration and updated signals. 
+          
+            
+        // }
+
+            const internalSignals = [...this.anchors.keys()]
+            .filter(key => key.endsWith('_internal'))
+            .map(key => {
+                //no need to get constraints as constraints would have had it be already
+                // get the transform 
+                const constraints = inputContext[key] || ["VGX_SIGNAL_NAME"];
+               
+                console.log('keys', key, key.split('_'), this.configurations)
+                const config = this.configurations[key.split('_')[0]];
+                console.log('generatedKEYSIGNAL', config, config.transforms)
+                const compatibleTransforms = config.transforms.filter(transform => transform.channel === key.split('_')[1])
+                console.log('compatibleTransforms', compatibleTransforms)
+                return compatibleTransforms.map(transform => generateSignal({
+                    id: nodeId,
+                    transform: transform,
+                    output: nodeId + '_' + key,
+                    constraints: constraints
+                }))
+            }
+             
+            ).flat();
+       
+        return {
+            params: [
+                {
+                    "name": this.id,
+                    "value": lineBaseContext,
+                },
+                ...outputSignals,
+                ...internalSignals
+            ],
+            "data":{"values":[{}]}, //TODO FIX
+            mark: {
+                type: "rule",
+                name: `${this.id}_marks`
+            },
+            "encoding": {
+                "x": {
+                    "value": { "expr": `${this.id}_position_x_start` },
+                },
+                "y": {
+                    "value": { "expr": `${this.id}_position_y_start` },
+                },
+                "x2": {
+                    "value": { "expr": `${this.id}_position_x_stop` },
+                },
+                "y2": {
+                    "value": { "expr": `${this.id}_position_y_stop` },
+                },
+                "size": {"value": {"expr": 1}},
+                "color": {"value": {"expr": "'red'"}},
+                "stroke": {"value": {"expr": "'red'"}}
+                // "stroke": {
+                //     "value": { "expr": inputContext.stroke || circleBaseContext.stroke }
+                // }
+            }
+        }
+    }
+}

--- a/src/components/marks/line.ts
+++ b/src/components/marks/line.ts
@@ -8,14 +8,15 @@ import { generateSignalFromAnchor, createRangeAccessor, generateCompiledValue, g
 import { extractSignalNames } from "../../binding/mergedComponent_CLEAN";
 
 const lineBaseContext = {
-    "x":{
-        start: 0,
-        stop: 1000
-       },
-       "y":{
-        start: 0,
-        stop: 1000
-       },
+    "start":{
+        "x": 0,
+        "y": 0
+    },
+    "stop":{
+        "x": 1000,
+        "y": 1000
+    },
+   
     "color": "'red'",
     "stroke": "'white'"
 }
@@ -36,10 +37,10 @@ const configurations = [{
         }
     },
     "transforms": [
-        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
-        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
-        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
-        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.stop"}, //data set y value will be each y value.
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.start.x" }, // treat x like a scalar
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.stop.x" }, // treat x like a scalar
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.start.y" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.stop.y"}, //data set y value will be each y value.
     ]
 },{
     'id': 'x',
@@ -58,10 +59,10 @@ const configurations = [{
     },
     "transforms": [
         { "name": "x", "channel": "x", "value": "PARENT_ID.x.start" },
-        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
-        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.start" }, // treat x like a scalar
-        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
-        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.stop"}, //data set y value will be each y value.
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.start.x" }, // treat x like a scalar
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.stop.x" }, // treat x like a scalar
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.start.y" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.stop.y"}, //data set y value will be each y value.
     ]
 },{
     'id': 'y',
@@ -78,10 +79,10 @@ const configurations = [{
         }
     },
     "transforms": [
-        { "name": "x_start", "channel": "x", "value": "PARENT_ID.x.start" },
-        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.x.stop" },
-        { "name": "y_start", "channel": "y", "value": "PARENT_ID.y.start" },
-        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.y.start" },
+        { "name": "x_start", "channel": "x", "value": "PARENT_ID.start.x" },
+        { "name": "x_stop", "channel": "x", "value": "PARENT_ID.stop.x" },
+        { "name": "y_start", "channel": "y", "value": "PARENT_ID.start.y" },
+        { "name": "y_stop", "channel": "y", "value": "PARENT_ID.stop.y" },
     ]
 }];
 
@@ -254,7 +255,6 @@ function computeDefaultValue(schema, transformName, channel) {
             // For sets, use first value or a reasonable default
             const values = lineBaseContext[channel]?.values;
             return values && values.length > 0 ? values[0] : 0;
-            
         default:
             // Fallback to base context or zero
             return lineBaseContext[channel] || 0;

--- a/src/components/marks/line.ts
+++ b/src/components/marks/line.ts
@@ -124,28 +124,14 @@ export class Line extends BaseComponent {
       
         });
 
-        console.log('this.anchors.line', this.anchors)
 
-        // // Create anchors for each schema item
-        // Object.keys(this.schema).forEach(key => {
-        //     const schemaValue = schema[key];
-        //     const keyName = config.id + '_' + key
-        //     console.log('creating anchor for ', keyName)
-        //     console.log('setting schema', keyName, schemaValue)
-        //     this.schema[keyName] = schemaValue;
-        //     this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
-        //         const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-        //         console.log('generatedAnchor', generatedAnchor)
-        //         return generatedAnchor
-        //     }));
-        // });
+      
     }
 
     compileComponent(inputContext: compilationContext): Partial<UnitSpec<Field>> {
         const nodeId = inputContext.nodeId || this.id;
 
 
-        console.log('inputContextLINE', inputContext)
 
         // // TODO handle missing key/anchors
         // const outputSignals = Object.keys(this.schema).map(key =>
@@ -173,158 +159,18 @@ export class Line extends BaseComponent {
                     constraintMap
                 );
 
-                console.log('generatedSignals', generatedSignals)
                 return generatedSignals.map(signal => {
                     signal.expr= signal.on.find(on=>!!on.update)?.update
-                    console.log('signalEXPr', signal.expr)
                     return signal
                 })
             });
 
-            function removeEmptySignals(signals: any[]): any[] {
-                return signals.filter(signal => {
-                    console.log('signalUpdateCheck', signal, signal?.on, !signal?.on, signal.on?.length === 0);
-                    
-                    // If signal has no valid update mechanism (no expr, empty update, and no on events with updates)
-                    // then only keep it if it has a non-empty value
-                    if ((signal.expr === undefined || signal.expr === null || signal.expr === '') && 
-                        (signal.update === undefined || signal.update === null || signal.update === '') && 
-                        (!signal?.on || signal.on?.length === 0)) {
-                        return !(signal.value === undefined || signal.value === null || signal.value === '');
-                    }
-                    
-                    // Clean up empty update statements in 'on' array
-                    if (signal.on && Array.isArray(signal.on)) {
-                       
-                        signal.on = signal.on.filter((onItem: any) => 
-                            !(onItem.update === undefined || onItem.update === null || onItem.update === '')
-                        );
-                        if(signal.on?.length === 0){
-                            return false;
-                        }
-                    }
-                    
-                    return true;
-                });
-            }
-
-
-            let outputSignals = removeEmptySignals(generatedSignals)
-            console.log('outputSignalsREMOVED', outputSignals)
-
-            const [otherConfigurations, newOutputSignals] = fillInMissingContent(this.configurations, outputSignals)
-
-            console.log('otherConfigurations', otherConfigurations)
-            console.log('newOutputSignals', newOutputSignals)
-
-            outputSignals = newOutputSignals
-            console.log('changedOutput', outputSignals)
-
-
-
-
-/**
- * Computes a default value based on schema container type and channel
- * @param schema The schema definition (contains container type)
- * @param transformName The name of the transform (e.g., x_start, y_stop)
- * @param channel The channel name (e.g., x, y)
- * @returns The appropriate default value
- */
-function computeDefaultValue(schema, transformName, channel) {
-    // Default values based on container type
-    switch (schema.container) {
-        case 'Range':
-            // For ranges, use start/stop based on transform name
-            if (transformName.endsWith('_start')) {
-                return `range('${channel}')[1]`
-            } else if (transformName.endsWith('_stop')) {
-                return `range('${channel}')[0]`
-            }
-            return 0;
             
-        case 'Scalar':
-            // For scalars, use direct value
-            if (channel === 'x' || channel === 'y') {
-                return `(range('${channel}')[0]+range('${channel}')[1])/2`;
-            } else if (channel === 'color' || channel === 'stroke') {
-                return "'red'"; // Default color as string expression
-            }
-            return 0;
-            
-        case 'Set':
-            // For sets, use first value or a reasonable default
-            const values = lineBaseContext[channel]?.values;
-            return values && values.length > 0 ? values[0] : 0;
-        default:
-            // Fallback to base context or zero
-            return lineBaseContext[channel] || 0;
-    }
-}
-            /**
- * Fills in missing values in configuration with defaults
- * @param configuration The configuration object that may have missing values
- * @param outputSignals The signals array that needs to be updated with defaults
- * @returns An object with updated configuration and signals
- */
-function fillInMissingContent(configuration: any, outputSignals: any) {
-    // Get the default configuration from your configurations array
-    const defaultConfig = configurations.find(cfg => cfg.default === true);
-    if (!defaultConfig) return { configuration, outputSignals };
-    
-    // For each schema item in the default configuration
-    Object.entries(defaultConfig.schema || {}).forEach(([channel, schemaValue]) => {
-        // Check if this channel is bound in the current configuration
-        const isBound = outputSignals.some((signal: any) => 
-            signal.name.includes(`_${defaultConfig.id}_${channel}`)
-        );
-        console.log('isBound', isBound, channel, `_${defaultConfig.id}_${channel}`);
-        
-        // If not bound, add default signals based on container type
-        if (!isBound) {
-            // Get transforms for this channel from the configuration
-            const relevantTransforms = defaultConfig.transforms.filter(transform => 
-                transform.channel === channel
-            );
-            
-            // For each transform that needs a default value
-            relevantTransforms.forEach(transform => {
-                const signalName = `${nodeId}_${defaultConfig.id}_${transform.name}`;
-                const defaultValue = computeDefaultValue(schemaValue, transform.name, channel);
-                console.log('relevanttransform', defaultConfig, transform, signalName, defaultValue);
-                
-                // Check if the signal exists
-                const existingSignalIndex = outputSignals.findIndex((s: any) => s.name === signalName);
-                console.log('existingSignalIndex', existingSignalIndex);
-                
-                if (existingSignalIndex >= 0) {
-                    // Update existing signal
-                    outputSignals[existingSignalIndex] = {
-                        name: signalName,
-                        expr: defaultValue
-                    };
-                } else {
-                    // Signal is missing entirely, create it
-                    outputSignals.push({
-                        name: signalName,
-                        expr: defaultValue
-                    });
-                }
-            });
-        }
-    });
-    
-    return [ configuration, outputSignals ];
-}
+            let outputSignals = (generatedSignals)
 
-        // function fillInMissingContent(configuration, outputSingals) {
-        //     // e.g. elaborate missing bits of information
-        //     // grab default configuration. 
-        //     // then for each schema value in it, if its not bound, change each of its corresponding signals to be the default value 
-        //     // create a function that computes the default value based on the container type. 
-        //     // return the updated configuration and updated signals. 
-          
-            
-        // }
+
+
+
 
             const internalSignals = [...this.anchors.keys()]
             .filter(key => key.endsWith('_internal'))
@@ -333,11 +179,8 @@ function fillInMissingContent(configuration: any, outputSignals: any) {
                 // get the transform 
                 const constraints = inputContext[key] || ["VGX_SIGNAL_NAME"];
                
-                console.log('keys', key, key.split('_'), this.configurations)
                 const config = this.configurations[key.split('_')[0]];
-                console.log('generatedKEYSIGNAL', config, config.transforms)
                 const compatibleTransforms = config.transforms.filter(transform => transform.channel === key.split('_')[1])
-                console.log('compatibleTransforms', compatibleTransforms)
                 return compatibleTransforms.map(transform => generateSignal({
                     id: nodeId,
                     transform: transform,

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -213,10 +213,8 @@ interface Transform {
       .filter(node => node !== output)
       .map(node => ({ signal: node }));
     
-      const triggerEvents = [{ signal: id },]
        // ...dependentNodes] TODO FIX DEPENDENCTS
     const uniqueTriggerEvents = [...new Set(dependentNodes.map(JSON.stringify))].map(JSON.parse);
-    console.log('uniqueTriggerEvents', uniqueTriggerEvents)
     // Return the signal definition
     return {
       name: output,

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { Circle } from './components/marks';
 
 import { Scatterplot, Histogram, LinePlot, BarChart, Heatmap, PieChart } from './components/charts';
 import { Circle } from './components/marks';
+import { Line } from './components/marks';
 import { CombinedDrag, Drag } from './components/interactions';  
 import { Brush as Brush2 } from './components/interactions/Instruments/Brush';
 import { Rect } from './components/marks/rect';
@@ -28,4 +29,5 @@ export const all = {
   drag: (config:any)=> new CombinedDrag(config),
   brush: (config:any)=> new CombinedDrag(config),
   rect: (config:any)=> new Rect(config),
+  line: (config:any)=> new Line(config),
 };


### PR DESCRIPTION
This PR adds support for line marks. In doing so, it adds support for implicit edges, which are edges that are added to ensure that context propagates between parent and child, even if it is not specifically bound together.