### PR TITLE
Data Transform actions 

### DIFF
--- a/src/binding/BindingManager.ts
+++ b/src/binding/BindingManager.ts
@@ -66,6 +66,12 @@ export class BindingManager {
         this.components.set(component.id, component);
     }
 
+    public removeComponent(componentId: string): void {
+        console.log('removing component', componentId)
+        this.components.delete(componentId);
+    }
+
+
 
     // Bindings 
     public getBindings(): Binding[] {

--- a/src/binding/BindingManager.ts
+++ b/src/binding/BindingManager.ts
@@ -34,6 +34,7 @@ export class BindingManager {
         // Initialize dependencies lazily
         this.graphManager = new GraphManager(() => this);
         this.specCompiler = new SpecCompiler(this.graphManager, () => this);
+        console.log("BINDINGGRAPHE",this)
     }
 
     public getProcessedGraph(id: string): ProcessedGraph {
@@ -92,6 +93,10 @@ export class BindingManager {
         }
         this.bindings.push({ sourceId, targetId, sourceAnchor, targetAnchor });
     };
+
+    public removeBinding(sourceId: string, targetId: string, sourceAnchor: string, targetAnchor: string): void {
+        this.bindings = this.bindings.filter(binding => binding.sourceId !== sourceId || binding.targetId !== targetId || binding.sourceAnchor !== sourceAnchor || binding.targetAnchor !== targetAnchor);
+    }
 
 
     /* 

--- a/src/binding/BindingManager.ts
+++ b/src/binding/BindingManager.ts
@@ -34,7 +34,6 @@ export class BindingManager {
         // Initialize dependencies lazily
         this.graphManager = new GraphManager(() => this);
         this.specCompiler = new SpecCompiler(this.graphManager, () => this);
-        console.log("BINDINGGRAPHE",this)
     }
 
     public getProcessedGraph(id: string): ProcessedGraph {
@@ -62,12 +61,11 @@ export class BindingManager {
         return component;
     }
 
-    public addComponent(component: BaseComponent): void {
+public addComponent(component: BaseComponent): void {
         this.components.set(component.id, component);
     }
 
     public removeComponent(componentId: string): void {
-        console.log('removing component', componentId)
         this.components.delete(componentId);
     }
 

--- a/src/binding/GraphManager.ts
+++ b/src/binding/GraphManager.ts
@@ -54,14 +54,13 @@ export class GraphManager {
 
             addNode(component);
 
-            // Get all bindings where this component is either source or target
+            // Get all bindings where this component is either source or target to catch nodes
+            // that are not accdssible through the root node
             const allBindings = this.bindingManager.getBindingsForComponent(componentId, 'both');
             
-            console.log('allBindings', allBindings)
             // Process source bindings
             allBindings.forEach(binding => {
                 const { sourceId, targetId, sourceAnchor, targetAnchor } = binding;
-                console.log('allBindings', binding, sourceId, targetId);
                 [sourceId, targetId].forEach(id => {
                     const comp = this.bindingManager.getComponent(id);
                     if (comp) addNode(comp);
@@ -103,8 +102,6 @@ export class GraphManager {
         // Replace the original arrays with de-duplicated ones
         nodes = uniqueNodes;
         edges = uniqueEdges;
-        console.log('uniqueNodes', uniqueNodes)
-        console.log('uniqueEdges', uniqueEdges)
         return { nodes, edges };
     }
 

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -46,7 +46,6 @@ export class LazyBindingRegistry {
     static resolve(componentType: string, realComponent: BaseComponent): void {
         const pending = this.pendingBindings.get(componentType) || [];
 
-        console.log("RESOLVINGNEW", pending, 'on:', realComponent, this.pendingBindings, componentType)
         if (pending.length == 0) {
             return;
         }
@@ -55,7 +54,6 @@ export class LazyBindingRegistry {
             // Find all bindings to the fake proxy
             const bindings = this.bindingManager.getBindingsForComponent(lazyComponent.id, 'target');
 
-            console.log("BINDINGS", bindings, lazyComponent.id, this.bindingManager.getBindings())
             // Rewrite each binding to point to the real component
             bindings.forEach(binding => {
                 // Remove the old binding
@@ -80,9 +78,14 @@ export class LazyBindingRegistry {
                         }
                     }
                 }
-                console.log('comp', lazyComponent, lazyComponent);
-                const realBrush = this.bindingManager.getComponent(realComponent.id);
-                console.log('realBrush', realBrush,binding.targetAnchor, realComponent.data, realComponent.brush  )
+
+                let realBrush = this.bindingManager.getComponent(realComponent.id);
+                realBrush = realBrush.data;
+
+                if(realBrush){
+                    realBrush = realBrush.toComponent();
+                    this.bindingManager.addComponent(realBrush);
+                }
                     
 
 

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -1,7 +1,7 @@
 import { BaseComponent } from "../components/base";
 import { BindingManager } from "./BindingManager";
 
-type LazyOperation = {
+export type LazyOperation = {
     type: 'count' | 'filter' | 'groupby' | 'percent';
     args: any[];
 }
@@ -56,51 +56,32 @@ export class LazyBindingRegistry {
 
             // Rewrite each binding to point to the real component
             bindings.forEach(binding => {
-                // Remove the old binding
-                this.bindingManager.removeBinding(
-                    binding.sourceId,
-                    binding.targetId,
-                    binding.sourceAnchor,
-                    binding.targetAnchor
-                );
 
-                
+                //TODO implement a extension type for DataAccessor components to fix type errors
                 let realBrush = this.bindingManager.getComponent(realComponent.id);
-                
                 let accessor = realBrush;
                 if(realBrush){
-                    console.log('realBrush', realBrush)
                     realBrush = realBrush.data;
                     realBrush = realBrush.toComponent();
                     this.bindingManager.addComponent(realBrush);
                 }
 
-                if(accessor){
-                    accessor = accessor.data;
-                    console.log('new accessor', accessor)
-                }
-
-
-                // Apply operations to get the final value
-                let value = accessor;
-                console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', accessor)
-                for (const op of lazyComponent.operations) {
-                    console.log('PUSHING OP', op.type, op.args, value)
-                    if (value && value[op.type]) {
-                        // if (op.args) {
-                            console.log('PUSHING OPWITH ARGS', value[op.type], op.args)
-                            value = value[op.type](...op.args);
-                        // } else {
-                            // value = value[op.type];
-                        // }
-                    }
-                }
-
                 
-                // console.log('realBrush', realBrush)
-                    
+                if(accessor){
+                    console.log('accessor@@#', accessor)
+                    accessor = accessor.data;
+                    accessor.applyOperations(accessor, lazyComponent.operations);
+                }
 
-
+               
+                // remove old binding 
+                 this.bindingManager.removeBinding(
+                    binding.sourceId,
+                    binding.targetId,
+                    binding.sourceAnchor,
+                    binding.targetAnchor
+                );
+                
                 // Create the inverse binding as these are cases where text should be created via the brush. 
                 this.bindingManager.addBinding(
                    
@@ -110,7 +91,6 @@ export class LazyBindingRegistry {
                     binding.targetAnchor,
                     binding.sourceAnchor
                 );
-                console.log('bindingsNOW', this.bindingManager.getBindings()   );
             });
         });
 

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -68,7 +68,6 @@ export class LazyBindingRegistry {
 
                 
                 if(accessor){
-                    console.log('accessor@@#', accessor)
                     accessor = accessor.data;
                     accessor.applyOperations(accessor, lazyComponent.operations);
                 }

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -66,9 +66,11 @@ export class LazyBindingRegistry {
                     binding.targetAnchor
                 );
 
+                
+
                 // Apply operations to get the final value
                 let value = realComponent;
-                console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', realComponent)
+                // console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', realComponent)
                 for (const op of lazyComponent.operations) {
                     if (value && value[op.type]) {
                         if (op.args) {
@@ -78,13 +80,20 @@ export class LazyBindingRegistry {
                         }
                     }
                 }
+                console.log('comp', lazyComponent, lazyComponent);
+                const realBrush = this.bindingManager.getComponent(realComponent.id);
+                console.log('realBrush', realBrush,binding.targetAnchor, realComponent.data, realComponent.brush  )
+                    
 
-                // Create new binding to the real component
+
+                // Create the inverse binding as these are cases where text should be created via the brush. 
                 this.bindingManager.addBinding(
-                    binding.sourceId,
+                   
                     realComponent.id,
-                    binding.sourceAnchor,
-                    binding.targetAnchor
+                    binding.sourceId,
+                    
+                    binding.targetAnchor,
+                    binding.sourceAnchor
                 );
             });
         });

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -1,0 +1,136 @@
+import { BaseComponent } from "../components/base";
+import { BindingManager } from "./BindingManager";
+
+type LazyOperation = {
+    type: 'count' | 'filter' | 'groupby' | 'percent';
+    args: any[];
+}
+let fakeProxyCounter = 0;
+
+export class LazyComponent {
+    id: string;
+    componentType: string;
+    operations: LazyOperation[];
+
+    constructor(componentType: string, operations: LazyOperation[] = []) {
+        this.id = `FAKEPROXY_${fakeProxyCounter++}`;
+        this.componentType = componentType;
+        this.operations = operations;
+    }
+
+    bind(parentComponent: BaseComponent, propertyName: string): void {
+        const bindingManager = BindingManager.getInstance();
+
+        // Create temporary binding to the fake proxy
+        bindingManager.addBinding(
+            parentComponent.id,
+            this.id,
+            propertyName,
+            'data' // Default anchor for data access
+        );
+    }
+}
+
+export class LazyBindingRegistry {
+    private static pendingBindings: Map<string, LazyComponent[]> = new Map();
+    private static bindingManager = BindingManager.getInstance();
+
+    static register(lazyComponent: LazyComponent): void {
+        const componentType = lazyComponent.componentType;
+        if (!this.pendingBindings.has(componentType)) {
+            this.pendingBindings.set(componentType, []);
+        }
+        this.pendingBindings.get(componentType)!.push(lazyComponent);
+    }
+
+    static resolve(componentType: string, realComponent: BaseComponent): void {
+        const pending = this.pendingBindings.get(componentType) || [];
+
+        console.log("RESOLVINGNEW", pending, 'on:', realComponent, this.pendingBindings, componentType)
+        if (pending.length == 0) {
+            return;
+        }
+        // Process each pending lazy component
+        pending.forEach(lazyComponent => {
+            // Find all bindings to the fake proxy
+            const bindings = this.bindingManager.getBindingsForComponent(lazyComponent.id, 'target');
+
+            console.log("BINDINGS", bindings, lazyComponent.id, this.bindingManager.getBindings())
+            // Rewrite each binding to point to the real component
+            bindings.forEach(binding => {
+                // Remove the old binding
+                this.bindingManager.removeBinding(
+                    binding.sourceId,
+                    binding.targetId,
+                    binding.sourceAnchor,
+                    binding.targetAnchor
+                );
+
+                // Apply operations to get the final value
+                let value = realComponent;
+                console.log("RESOLVING", lazyComponent.operations, 'on:', realComponent)
+                for (const op of lazyComponent.operations) {
+                    if (value && value[op.type]) {
+                        if (op.args) {
+                            value = value[op.type](...op.args);
+                        } else {
+                            value = value[op.type];
+                        }
+                    }
+                }
+
+                // Create new binding to the real component
+                this.bindingManager.addBinding(
+                    binding.sourceId,
+                    realComponent.id,
+                    binding.sourceAnchor,
+                    binding.targetAnchor
+                );
+            });
+        });
+
+
+        this.pendingBindings.delete(componentType);
+    }
+}
+
+export function createLazyAccessor(componentType: string, operations: LazyOperation[] = []): any {
+    const lazyComponent = new LazyComponent(componentType, operations);
+    LazyBindingRegistry.register(lazyComponent);
+
+    return new Proxy({}, {
+        
+        get(target, prop) {
+
+            if(prop == 'isLazy'){
+                return true;
+            }
+
+            if(prop == 'id'){
+                return lazyComponent.id;
+            }
+
+            if (prop === 'count') {
+                lazyComponent.operations.push({ type: 'count', args: [] })
+                return () => createLazyAccessor(componentType, [...operations, { type: 'count', args: [] }]);
+            }
+            if (prop === 'filter') {
+                lazyComponent.operations.push({ type: 'count', args: [] })
+                return (expr: string) => createLazyAccessor(componentType, [...operations, { type: 'filter', args: [expr] }]);
+            }
+            if (prop === 'groupby') {
+                lazyComponent.operations.push({ type: 'count', args: [] })
+
+                return (...fields: string[]) => createLazyAccessor(componentType, [...operations, { type: 'groupby', args: fields }]);
+            }
+            if (prop === 'percent') {
+                lazyComponent.operations.push({ type: 'count', args: [] })
+
+                return createLazyAccessor(componentType, [...operations, { type: 'percent', args: [] }]);
+            }
+
+            lazyComponent.operations.push({ type: prop, args: null })// if null args, then use as a property not a fn
+            return createLazyAccessor(componentType, []);
+        }
+    });
+}

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -68,7 +68,7 @@ export class LazyBindingRegistry {
 
                 // Apply operations to get the final value
                 let value = realComponent;
-                console.log("RESOLVING", lazyComponent.operations, 'on:', realComponent)
+                console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', realComponent)
                 for (const op of lazyComponent.operations) {
                     if (value && value[op.type]) {
                         if (op.args) {

--- a/src/binding/LazyBinding.ts
+++ b/src/binding/LazyBinding.ts
@@ -65,39 +65,52 @@ export class LazyBindingRegistry {
                 );
 
                 
-
-                // Apply operations to get the final value
-                let value = realComponent;
-                // console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', realComponent)
-                for (const op of lazyComponent.operations) {
-                    if (value && value[op.type]) {
-                        if (op.args) {
-                            value = value[op.type](...op.args);
-                        } else {
-                            value = value[op.type];
-                        }
-                    }
-                }
-
                 let realBrush = this.bindingManager.getComponent(realComponent.id);
-                realBrush = realBrush.data;
-
+                
+                let accessor = realBrush;
                 if(realBrush){
+                    console.log('realBrush', realBrush)
+                    realBrush = realBrush.data;
                     realBrush = realBrush.toComponent();
                     this.bindingManager.addComponent(realBrush);
                 }
+
+                if(accessor){
+                    accessor = accessor.data;
+                    console.log('new accessor', accessor)
+                }
+
+
+                // Apply operations to get the final value
+                let value = accessor;
+                console.log("RESOLVINGVIA REAL COMPONENT", lazyComponent.operations, 'on:', accessor)
+                for (const op of lazyComponent.operations) {
+                    console.log('PUSHING OP', op.type, op.args, value)
+                    if (value && value[op.type]) {
+                        // if (op.args) {
+                            console.log('PUSHING OPWITH ARGS', value[op.type], op.args)
+                            value = value[op.type](...op.args);
+                        // } else {
+                            // value = value[op.type];
+                        // }
+                    }
+                }
+
+                
+                // console.log('realBrush', realBrush)
                     
 
 
                 // Create the inverse binding as these are cases where text should be created via the brush. 
                 this.bindingManager.addBinding(
                    
-                    realComponent.id,
+                    realBrush.id,
                     binding.sourceId,
                     
                     binding.targetAnchor,
                     binding.sourceAnchor
                 );
+                console.log('bindingsNOW', this.bindingManager.getBindings()   );
             });
         });
 

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -114,8 +114,6 @@ export class SpecCompiler {
 
         const mergedSpec = mergeSpecs(compiledSpecs, rootComponent.id);
 
-        console.log('DFSDDAF', mergedSpec)
-
 
         const patchManager = new VegaPatchManager(mergedSpec);
 
@@ -138,7 +136,6 @@ export class SpecCompiler {
             edges.some(edge => edge.source.nodeId === n.id && edge.target.nodeId === node.id)
         );
 
-        console.log('parentNodes for', parentNodes, 'for', node.id)
         
         if (parentNodes.length === 0) return [];
         
@@ -151,7 +148,6 @@ export class SpecCompiler {
         
         // 2. For each parent, find default configuration and compatible anchors
         for (const parentNode of parentNodes) {
-            console.log('parentNode', parentNode, parentNodes)
             // Skip merged nodes
             if (parentNode.type === 'merged') continue;
             
@@ -167,12 +163,10 @@ export class SpecCompiler {
             
             // Get all anchors for this parent
             const parentAnchors = parentComponent.getAnchors();
-            console.log('parentAnchors', parentAnchors)
             // Process each anchor
             parentAnchors.forEach(anchor => {
                 const anchorId = anchor.id.anchorId;
                 const channel = extractAnchorType(anchorId);
-                console.log('anchorId', anchorId, channel)
                 if (!channel) return;
                 
                 // Extract numeric value from anchor ID if present (e.g., "node_5_x" -> 5)
@@ -189,7 +183,6 @@ export class SpecCompiler {
                 }
             })
         }
-        console.log('highestAnchors', highestAnchors)
         // 3. Create implicit edges from highest parent anchors to this node
         for (const [channel, anchorInfo] of Object.entries(highestAnchors)) {
             // Find compatible target anchor on current node
@@ -233,7 +226,6 @@ export class SpecCompiler {
      */
     private compileBindingGraph(rootId: string, bindingGraph: BindingGraph): Partial<UnitSpec<Field>>[] {
         let { nodes, edges } = bindingGraph;
-        console.log('FIRST edges', edges,'nodes', nodes)
         const visitedNodes = new Set<string>();
         const constraintsByNode: Record<string, Record<string, any[]>> = {};
         const mergedNodeIds = new Set<string>();
@@ -269,23 +261,13 @@ export class SpecCompiler {
             }
 
 
-            console.log('ALLedges', edges)
             const implicitEdges = this.buildImplicitContextEdges(node, edges, nodes);
             edges = [...edges, ...implicitEdges]
             // Build constraints for this node
-            console.log('building constraints for', nodeId, 'edges', edges, 'nodes', nodes)
 
-            // Log edges that have node_4 as source or target
-            edges.forEach(edge => {
-                if (edge.source.nodeId === 'node_4' || edge.target.nodeId === 'node_4') {
-                    console.log('Edge with node_4:', edge);
-                }
-            });
-            // Log edges that have 'data' in their names (case insensitive)
-           
+          
             const constraints = this.buildNodeConstraints(node, edges, nodes);
 
-            console.log('constraints32', constraints, 'for', nodeId,node)
             
             // Store constraints for later use by merged nodes
             constraintsByNode[nodeId] = constraints;
@@ -297,13 +279,11 @@ export class SpecCompiler {
             const childSpecs = childNodeIds.flatMap(childId => traverseGraph(childId));
             // Find and traverse parent nodes
             const parentNodeIds = this.findParentNodes(node, edges, nodes);
-            console.log('parentNodes', parentNodeIds, node,nodes)
             const parentSpecs = parentNodeIds.flatMap(parentId => {
                 // Skip if already visited to prevent infinite loops
                 if (visitedNodes.has(parentId)) {
                     return [];
                 }
-                console.log('finding parent', parentId)
                 return traverseGraph(parentId);
             });
             
@@ -385,7 +365,6 @@ export class SpecCompiler {
                 generateRangeConstraints(parentNodeSchema, anchorAccessor)
             );
         } else if (currentNodeSchema.container === "Data") {
-            console.log('data constraints', parentNodeSchema, anchorAccessor)
             
                 constraints[targetAnchorId].push(
                     generateDataConstraints(parentNodeSchema, anchorAccessor)
@@ -409,28 +388,6 @@ export class SpecCompiler {
         const parentEdges = edges.filter(edge => edge.target.nodeId === node.id);
         const constraints: Record<AnchorId, Constraint[]> = {};
 
-        // console.log('parentEdges', parentEdges, 'for', node.id)
-        // // Initialize data edges array to track data bindings
-        // const dataEdges = parentEdges.filter(edge => {
-        //     const targetComponent = this.getBindingManager().getComponent(edge.target.nodeId);
-        //     if (!targetComponent) return false;
-            
-        //     const targetAnchorId = edge.target.anchorId;
-        //     const cleanTargetId = targetAnchorId.replace('_internal', '');
-        //     const schema = targetComponent.schema[cleanTargetId];
-            
-        //     return schema && schema.container === 'Data';
-        // });
-
-        // console.log('dataEdges', dataEdges)
-        
-        // // Log data edges for debugging
-        // if (dataEdges.length > 0) {
-        //     console.log('Data edges for component', node.id, ':', dataEdges.map(edge => ({
-        //         source: `${edge.source.nodeId}.${edge.source.anchorId}`,
-        //         target: `${edge.target.nodeId}.${edge.target.anchorId}`
-        //     })));
-        // }
 
         // Process each parent edge
         for (const parentEdge of parentEdges) {
@@ -457,7 +414,6 @@ export class SpecCompiler {
             const cleanTargetId = targetAnchorId.replace('_internal', '');
 
             const currentNodeSchema = component.schema[cleanTargetId]
-            console.log('currentNodeSchema', currentNodeSchema, parentEdge.source.nodeId, parentEdge.source.anchorId)
             const parentNodeSchema = anchorProxy.anchorSchema[parentEdge.source.anchorId];
             
             // Skip if no schema exists for this channel
@@ -467,9 +423,7 @@ export class SpecCompiler {
             if (!constraints[targetAnchorId]) {
                 constraints[targetAnchorId] = [];
             }
-            if (parentNode.id === 'node_4') {
-                console.log('adding constraint for', targetAnchorId,constraints, currentNodeSchema, parentNodeSchema, anchorProxy);
-            }
+        
             // Add appropriate constraint based on component schema type
             this.addConstraintForChannel(
                 constraints,

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -99,7 +99,7 @@ export class SpecCompiler {
 
         const prunedEdges = pruneEdges(rootComponent.id, expandedEdges);
 
-        
+        console.log('prunedEdges', prunedEdges,expandedEdges)
         bindingGraph.edges = prunedEdges;
    
         const processedGraph = resolveCycleMulti(bindingGraph, this.getBindingManager());
@@ -243,6 +243,7 @@ export class SpecCompiler {
             edges.push(implicitEdge);
         }
         
+       
         return edges;
     }
         
@@ -257,6 +258,7 @@ export class SpecCompiler {
      */
     private compileBindingGraph(rootId: string, bindingGraph: BindingGraph): Partial<UnitSpec<Field>>[] {
         let { nodes, edges } = bindingGraph;
+        console.log('bindinggraph',nodes, JSON.parse(JSON.stringify(edges)))
         const visitedNodes = new Set<string>();
         const constraintsByNode: Record<string, Record<string, any[]>> = {};
         const mergedNodeIds = new Set<string>();
@@ -315,6 +317,7 @@ export class SpecCompiler {
             return [compiledNode, ...childSpecs];
         };
 
+        console.log('edges', edges)
         // First pass: Traverse the graph starting from the root
         const regularSpecs = traverseGraph(rootId);
 

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -33,11 +33,10 @@ type Constraint = string;
 
 function generateScalarConstraints(schema: SchemaType, value: SchemaValue): string {
     if (schema.container === 'Data'){
-        console.log('GENERATING SCALAR CDATAONSTRAINTS', schema, value)
+        console.log('GENERATING DATA CONSTRAINTS', schema, value)
         return `datum[${value.value}]`;
     }
     if(schema.valueType === 'Categorical'){
-        console.log('GENERATING Scale categorical', value)
 
         return `${value.value}`;
     }
@@ -60,7 +59,6 @@ function generateScalarConstraints(schema: SchemaType, value: SchemaValue): stri
 // 
 function generateRangeConstraints(schema: SchemaType, value: SchemaValue): string {
     if(schema.valueType === 'Categorical'){
-        console.log('GENERATING RANGE categorical', value)
         // TODO: fix this
         return `${value.value}`;
     }
@@ -88,7 +86,6 @@ function generateRangeConstraints(schema: SchemaType, value: SchemaValue): strin
 }
 
 function generateDataConstraints(schema: SchemaType, value: SchemaValue): string {
-    console.log('GENERATING DATA CONSTRAINTS', schema, value)
     return `${value.value}`; 
 }
 
@@ -123,6 +120,7 @@ export class SpecCompiler {
         const mergedSpec = mergeSpecs(compiledSpecs, rootComponent.id);
 
 
+        console.log('vl spec',mergedSpec)
         const patchManager = new VegaPatchManager(mergedSpec);
 
         
@@ -274,22 +272,8 @@ export class SpecCompiler {
             // Build constraints for this node
 
             // Print edges that come from node_4
-            const node4Edges = edges.filter(edge => edge.source.nodeId === 'node_4');
-            if (node4Edges.length > 0) {
-                console.log('Edges from node_4:', node4Edges.map(edge => ({
-                    source: {
-                        nodeId: edge.source.nodeId,
-                        anchorId: edge.source.anchorId
-                    },
-                    target: {
-                        nodeId: edge.target.nodeId,
-                        anchorId: edge.target.anchorId
-                    }
-                })),nodes,nodeId);
-            }
-            console.log('BUILDING CONSTRAINTS', nodeId,edges,nodes)
+            
             const constraints = this.buildNodeConstraints(node, edges, nodes);
-            console.log('CONSTRAINTS32', constraints)
             
             // Store constraints for later use by merged nodes
             constraintsByNode[nodeId] = constraints;

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -33,7 +33,6 @@ type Constraint = string;
 
 function generateScalarConstraints(schema: SchemaType, value: SchemaValue): string {
     if (schema.container === 'Data'){
-        console.log('GENERATING DATA CONSTRAINTS', schema, value)
         return `datum[${value.value}]`;
     }
     if(schema.valueType === 'Categorical'){
@@ -120,7 +119,6 @@ export class SpecCompiler {
         const mergedSpec = mergeSpecs(compiledSpecs, rootComponent.id);
 
 
-        console.log('vl spec',mergedSpec)
         const patchManager = new VegaPatchManager(mergedSpec);
 
         
@@ -273,7 +271,6 @@ export class SpecCompiler {
 
             // Print edges that come from node_4
             
-            console.log('all edges', edges,nodeId ,nodes)
             const constraints = this.buildNodeConstraints(node, edges, nodes);
             
             // Store constraints for later use by merged nodes
@@ -425,18 +422,7 @@ export class SpecCompiler {
 
             const currentNodeSchema = component.schema[cleanTargetId]
             const parentNodeSchema = anchorProxy.anchorSchema[parentEdge.source.anchorId];
-            // Debug: If parentNode is node_4, print the schema
-            if (parentNode.id === 'node_4') {
-                console.log('Parent Node Schema for node_4:', {
-                    parentNodeId: parentNode.id,
-                    parentAnchorId: parentEdge.source.anchorId,
-                    parentSchema: parentNodeSchema,
-                    targetNodeId: node.id,
-                    targetAnchorId: targetAnchorId,
-                    targetSchema: currentNodeSchema
-                });
-            }
-            
+           
             // Skip if no schema exists for this channel
             if (!currentNodeSchema) continue;
 

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -273,6 +273,7 @@ export class SpecCompiler {
 
             // Print edges that come from node_4
             
+            console.log('all edges', edges,nodeId ,nodes)
             const constraints = this.buildNodeConstraints(node, edges, nodes);
             
             // Store constraints for later use by merged nodes

--- a/src/binding/SpecCompiler.ts
+++ b/src/binding/SpecCompiler.ts
@@ -94,6 +94,7 @@ export class SpecCompiler {
         // specific binding graph for this tree
         let bindingGraph = this.graphManager.generateBindingGraph(rootComponent.id);
 
+        console.log('2bjksjcjkasb', JSON.parse(JSON.stringify(bindingGraph.edges)))
         // expand any _all anchors to individual anchors
         const expandedEdges = expandEdges(bindingGraph.edges);
 
@@ -148,6 +149,8 @@ export class SpecCompiler {
                 }
             }
         })
+
+        console.log('bindign graph', processedGraph)
 
         vegaCompilation.spec.signals = existingSignals;
 

--- a/src/binding/cycles.ts
+++ b/src/binding/cycles.ts
@@ -14,10 +14,8 @@ export function resolveCycles(edges: BindingEdge[], allNodes: Map<string, Bindin
     const expandedEdges = deepClone(edges);
 
     const cycleNodesArray = Array.from(cycleNodes);
-    console.log('cycleNodesArray', JSON.parse(JSON.stringify(cycleNodesArray)), JSON.parse(JSON.stringify(cycleEdges)),'creating:',cycleEdges[0].target.anchorId,JSON.parse(JSON.stringify(cycleEdges)))
     const mergedComponent = createMergedComponent(cycleNodesArray[0], cycleNodesArray[1], cycleEdges[0].target.anchorId, bindingManager);
 
-    console.log('mergedComponent', mergedComponent)
 
     // Create a new merged node ID
     const mergedNodeId = mergedComponent.id;
@@ -39,20 +37,13 @@ export function resolveCycles(edges: BindingEdge[], allNodes: Map<string, Bindin
             // component: mergedComponent
         });
 
-    // bindingGraph.nodes.set(mergedNodeId, {
-    //     id: mergedNodeId,
-    //     type: 'merged',
-    //     // component: mergedComponent
-    // });
-    console.log('cycleNodes', JSON.parse(JSON.stringify(cycleNodes)))
-
+    
     // Remove cycle edges
     const newEdges = expandedEdges.filter(edge => {
         // Filter out edges between cycle nodes
         return !(cycleNodesArray.find(node => node === edge.source.nodeId) && cycleNodesArray.find(node => node === edge.target.nodeId) && edge.target.anchorId !== targetAnchorId )
     });
 
-    console.log('newEdges', JSON.parse(JSON.stringify(newEdges)))
 
     // Add new edges from each component to the merged component
     cycleNodes.forEach(nodeId => {
@@ -89,15 +80,12 @@ export function resolveCycles(edges: BindingEdge[], allNodes: Map<string, Bindin
 
             // Modify the compile function of the cloned anchor
             clonedAnchor.compile = () => {
-                console.log('originalResult', originalResult, `${originalAnchor.id.componentId}-${originalResult.value}_internal`)
                 // Handle different SchemaValue types (ScalarValue, SetValue, RangeValue)
                 if ('value' in originalResult) {
                     const value = originalResult.value;
-                    console.log('prereplace', value)
                     // Use the return value of replace since strings are immutable
                     const updatedValue = value.replace('VGX_SIGNAL_NAME', `${originalAnchor.id.componentId}`);
 
-                    console.log('postreplace', updatedValue)
                     return { value: `${updatedValue}_internal` };
                 } else {
                     // For other types, just return a modified version
@@ -106,8 +94,6 @@ export function resolveCycles(edges: BindingEdge[], allNodes: Map<string, Bindin
             };
 
 
-            console.log('originalAnchor', originalAnchor)
-            console.log('originalComponent', originalComponent)
 
             function deepClone(obj: any) {
                 return JSON.parse(JSON.stringify(obj));
@@ -115,7 +101,6 @@ export function resolveCycles(edges: BindingEdge[], allNodes: Map<string, Bindin
 
             const internalAnchorId = `${anchorId}_internal`;
             // originalComponent.setAnchor(anchorId, clonedAnchor);
-            console.log('clonedAnchor', clonedAnchor)
             originalComponent.setAnchor(internalAnchorId, clonedAnchor); // this is the same as the original
             //now retarget all of the inczwoming edges to this new anchor
 

--- a/src/binding/cycles_CLEAN.ts
+++ b/src/binding/cycles_CLEAN.ts
@@ -257,6 +257,7 @@ export function resolveCycleMulti(
     let processedGraph = cloneGraph(graph);
     // Keep resolving cycles until none are left
     let cycles = detectCyclesByChannel(processedGraph.edges);
+    console.log('all cycles', cycles)
     let count = 10;
     // while (cycles.length > 0 && count > 0) {
         // Process each cycle
@@ -272,6 +273,7 @@ export function resolveCycleMulti(
                 return;
             }
             
+            console.log('creating merged component for cycle', cycleChannel, nodes)
             // Create merged component for this cycle
             const mergedComponent = createMergedComponentForChannel(
                 nodes,
@@ -345,6 +347,7 @@ function detectCyclesByChannel(edges: BindingEdge[]): Array<{ nodes: string[], e
         if (partitionEdges.length === 0) return;
 
         const partitionCycles = findCyclesInPartition(partitionEdges);
+        console.log('partitionCycles', partitionCycles)
         cycles.push(...partitionCycles);
     });
 
@@ -370,6 +373,7 @@ function detectCyclesByChannel(edges: BindingEdge[]): Array<{ nodes: string[], e
  * Finds cycles within a partition of edges with the same anchor ID.
  */
 function findCyclesInPartition(edges: BindingEdge[]): { nodes: string[], edges: BindingEdge[] }[] {
+    // TODO double cycles don't work....
     const cycles: Array<{ nodes: string[], edges: BindingEdge[] }> = [];
     const visited = new Set<string>();
     const stack = new Set<string>();

--- a/src/binding/cycles_CLEAN.ts
+++ b/src/binding/cycles_CLEAN.ts
@@ -9,12 +9,17 @@ import { AnchorType } from "../types/anchors";
 export function expandEdges(edges: BindingEdge[]): BindingEdge[] {  
     const expanded= edges.flatMap(edge => {
         const sourceComponent = BindingManager.getInstance().getComponent(edge.source.nodeId);
+        console.log('sourceComponent', sourceComponent)
         if (!sourceComponent) {
             throw new Error(`Source component ${edge.source.nodeId} not found`);
         }
         const targetComponent = BindingManager.getInstance().getComponent(edge.target.nodeId);
+        console.log('targetComponent', targetComponent)
         if (!targetComponent) {
             throw new Error(`Target component ${edge.target.nodeId} not found`);
+        }
+        if(edge.source.nodeId == "node_4"){
+            console.log('expanded edges',edge, expandGroupAnchors(edge, sourceComponent, targetComponent))
         }
         return expandGroupAnchors(edge, sourceComponent, targetComponent)
     })
@@ -30,6 +35,9 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
     const getAnchors = (component: BaseComponent, anchorId: string) => {
         // If it's _all, return all anchors
         if (anchorId === '_all') {
+            if(edge.source.nodeId == "node_4"){
+                console.log('ksdljflks',edge, [...component.getAnchors().values()].map(a => a.id.anchorId))
+            }
             return [...component.getAnchors().values()].map(a => a.id.anchorId);
         }
 
@@ -47,6 +55,8 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
             .filter(a => a.id.anchorId.includes(anchorId) && a.id.anchorId !== anchorId)
             .map(a => a.id.anchorId);
             
+
+        console.log('configAnchors', configAnchors)
         // If we found configuration-based anchors, return those
         if (configAnchors.length > 0) {
             return configAnchors;
@@ -55,9 +65,11 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
 
         const baseAnchorId = anchorId
         try {
+            console.log('baseAnchorId', baseAnchorId, component.getAnchor(baseAnchorId),component)
             component.getAnchor(baseAnchorId); // This will throw if anchor doesn't exist
             return [baseAnchorId];
         } catch (error) {
+            //throw new Error(`Anchor ${baseAnchorId} not found for component ${component.id}`);
             // Anchor doesn't exist, continue with empty array
             return [];
         }
@@ -66,6 +78,9 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
 
     const sourceAnchors = getAnchors(source, edge.source.anchorId);
     let targetAnchors = getAnchors(target, edge.target.anchorId);
+    if(edge.source.nodeId == "node_4"){
+        console.log('targetAnchors', targetAnchors,"sourceAnchors", sourceAnchors)
+    }
 
     return sourceAnchors.flatMap(sourceAnchor =>
         targetAnchors
@@ -81,7 +96,11 @@ export function extractAnchorType(anchorId: string): AnchorType | undefined {
     if (anchorId === '_all') return undefined;
     if (anchorId.includes('data')) {
         console.log('DATAfdsfsdds', anchorId)
-        return 'Data';
+        return 'data';
+    }
+    if (anchorId.includes('text')) {
+        console.log('TEXTfdsfsdds', anchorId)
+        return 'text';
     }
     
     // If it's a simple channel name that matches an AnchorType
@@ -107,7 +126,14 @@ export function isCompatible(sourceAnchorId: string, targetAnchorId: string) {
     
     
     const sourceChannel = extractAnchorType(sourceAnchorId);
+    console.log('sourceChannel', sourceChannel, 'anchoirId', sourceAnchorId)
     const targetChannel = extractAnchorType(targetAnchorId);
+    console.log('sourceChannel', sourceChannel, 'anchoirId', sourceAnchorId)
+
+
+    if(sourceChannel === 'text'){
+        console.log('sourceChannelTEXT', sourceChannel, 'targetChannel', targetChannel)
+    }
     if(!sourceChannel || !targetChannel) {
         return false;
     }

--- a/src/binding/cycles_CLEAN.ts
+++ b/src/binding/cycles_CLEAN.ts
@@ -79,6 +79,10 @@ function expandGroupAnchors(edge: BindingEdge, source: BaseComponent, target: Ba
 
 export function extractAnchorType(anchorId: string): AnchorType | undefined {
     if (anchorId === '_all') return undefined;
+    if (anchorId.includes('data')) {
+        console.log('DATAfdsfsdds', anchorId)
+        return 'Data';
+    }
     
     // If it's a simple channel name that matches an AnchorType
     const anchorTypeValues = Object.values(AnchorType) as string[];
@@ -257,7 +261,6 @@ export function resolveCycleMulti(
     let processedGraph = cloneGraph(graph);
     // Keep resolving cycles until none are left
     let cycles = detectCyclesByChannel(processedGraph.edges);
-    console.log('all cycles', cycles)
     let count = 10;
     // while (cycles.length > 0 && count > 0) {
         // Process each cycle
@@ -273,7 +276,6 @@ export function resolveCycleMulti(
                 return;
             }
             
-            console.log('creating merged component for cycle', cycleChannel, nodes)
             // Create merged component for this cycle
             const mergedComponent = createMergedComponentForChannel(
                 nodes,
@@ -347,7 +349,6 @@ function detectCyclesByChannel(edges: BindingEdge[]): Array<{ nodes: string[], e
         if (partitionEdges.length === 0) return;
 
         const partitionCycles = findCyclesInPartition(partitionEdges);
-        console.log('partitionCycles', partitionCycles)
         cycles.push(...partitionCycles);
     });
 

--- a/src/binding/prune.ts
+++ b/src/binding/prune.ts
@@ -25,9 +25,18 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
         for (const edge of outgoingEdges) {
             const sourceChannel = extractAnchorType(edge.source.anchorId);
             const targetChannel = extractAnchorType(edge.target.anchorId);
+
+
+            if(sourceChannel === 'Data'){
+                console.log('sourceChannelDATA', sourceChannel, 'edge', edge)
+                console.log('sourceChannelDATA', targetChannel)
+            }
             
             // If the source channel is valid, this edge is valid
             if (sourceChannel && validChannels.has(sourceChannel)) {
+                if(sourceChannel === 'Data'){
+                    console.log('sourceChannelDATAIN', sourceChannel, 'edge', edge)
+                }
                 validEdges.add(edge);
                 
                 // The target node can now use this channel
@@ -51,7 +60,6 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
         if (channel) rootChannels.add(channel);
     });
 
-    console.log('before target', edges.filter(edge => edge.target.nodeId === rootId))
     
     // Also include edges where root is the target
     edges.filter(edge => edge.target.nodeId === rootId).forEach(edge => {
@@ -59,7 +67,8 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
         if (channel) rootChannels.add(channel);
     });
 
-    console.log('after target', edges, rootChannels, rootId)
+    rootChannels.add('Data')
+
     
     // Start validation from the root
     validateEdgesForNode(rootId, rootChannels);

--- a/src/binding/prune.ts
+++ b/src/binding/prune.ts
@@ -50,12 +50,16 @@ export function pruneEdges(rootId: string, edges: BindingEdge[]): BindingEdge[] 
         const channel = extractAnchorType(edge.source.anchorId);
         if (channel) rootChannels.add(channel);
     });
+
+    console.log('before target', edges.filter(edge => edge.target.nodeId === rootId))
     
     // Also include edges where root is the target
     edges.filter(edge => edge.target.nodeId === rootId).forEach(edge => {
         const channel = extractAnchorType(edge.target.anchorId);
         if (channel) rootChannels.add(channel);
     });
+
+    console.log('after target', edges, rootChannels, rootId)
     
     // Start validation from the root
     validateEdgesForNode(rootId, rootChannels);

--- a/src/compilation/VLPatchCompiler.ts
+++ b/src/compilation/VLPatchCompiler.ts
@@ -1,0 +1,71 @@
+import { TopLevelSpec, UnitSpec } from "vega-lite/build/src/spec";
+import * as vl from "vega-lite";
+
+export class VLPatchCompiler {
+    private extractedDatasets: any[] = [];
+    private extractedSignals: any[] = [];
+
+    public compileWithPatches(spec: TopLevelSpec): TopLevelSpec {
+        // Step 1: Extract VGXMOD_ items
+        const cleanedSpec = this.extractVGXMODItems(spec);
+
+        // Step 2: Compile with Vega-Lite
+        const vegaSpec = vl.compile(cleanedSpec).spec;
+
+        // Step 3: Apply patches
+        return this.applyPatches(vegaSpec);
+    }
+
+    private extractVGXMODItems(spec: TopLevelSpec): TopLevelSpec {
+        // Handle datasets
+        if (spec.data) {
+            spec.data = spec.data.map(dataset => {
+                if (dataset.name?.startsWith('VGXMOD_')) {
+                    this.extractedDatasets.push(dataset);
+                    return { name: dataset.name };
+                }
+                return dataset;
+            });
+        }
+
+        // Handle signals
+        if (spec.signals) {
+            spec.signals = spec.signals.filter(signal => {
+                if (signal.name?.startsWith('VGXMOD_')) {
+                    this.extractedSignals.push(signal);
+                    return false;
+                }
+                return true;
+            });
+        }
+
+        // Handle nested specs (e.g., in layered or concatenated charts)
+        if (spec.layer) {
+            spec.layer = spec.layer.map(layer => this.extractVGXMODItems(layer));
+        }
+        if (spec.hconcat) {
+            spec.hconcat = spec.hconcat.map(h => this.extractVGXMODItems(h));
+        }
+        if (spec.vconcat) {
+            spec.vconcat = spec.vconcat.map(v => this.extractVGXMODItems(v));
+        }
+
+        return spec;
+    }
+
+    private applyPatches(vegaSpec: TopLevelSpec): TopLevelSpec {
+        // Add extracted datasets
+        if (this.extractedDatasets.length > 0) {
+            vegaSpec.data = vegaSpec.data || [];
+            vegaSpec.data.push(...this.extractedDatasets);
+        }
+
+        // Add extracted signals
+        if (this.extractedSignals.length > 0) {
+            vegaSpec.signals = vegaSpec.signals || [];
+            vegaSpec.signals.push(...this.extractedSignals);
+        }
+
+        return vegaSpec;
+    }
+} 

--- a/src/compilation/VegaPatchManager.ts
+++ b/src/compilation/VegaPatchManager.ts
@@ -22,7 +22,6 @@ export class VegaPatchManager {
         if(this.modifiedElements.data.length > 0){
             unreferencedRemoved.datasets = unreferencedRemoved.datasets || {}
             this.modifiedElements.data.forEach(dataset => {
-                console.log(`Added placeholder dataset: ${dataset.name}`);
                 unreferencedRemoved.datasets[dataset.name] = []
             })
         }
@@ -35,8 +34,6 @@ export class VegaPatchManager {
     public compile(){
         const vegaCompilation = vl.compile(this.spec);
 
-        console.log('vegaCompilation', vegaCompilation)
-        console.log('modifiedElements', this.modifiedElements)
 
 
          // Update data elements that match modified elements
@@ -47,7 +44,6 @@ export class VegaPatchManager {
                 );
                 
                 if (matchingModifiedData) {
-                    console.log(`Updating data element: ${dataElement.name} with modified data`,matchingModifiedData);
                     return matchingModifiedData ;
                 }
                 
@@ -64,7 +60,6 @@ export class VegaPatchManager {
             });
         }
 
-        console.log('vegaCompilation.spec.data', vegaCompilation.spec.data)
 
         // Update signals that match modified params
         if (vegaCompilation.spec.signals && this.modifiedElements.params.length > 0) {
@@ -74,7 +69,6 @@ export class VegaPatchManager {
                 );
                 
                 if (matchingParam && matchingParam.on && signal.on) {
-                    console.log(`Merging signal handlers for: ${signal.name}`);
                     // Create a new signal with merged 'on' arrays
                     return {
                         ...signal,

--- a/src/compilation/VegaPatchManager.ts
+++ b/src/compilation/VegaPatchManager.ts
@@ -1,0 +1,91 @@
+import { TopLevelSpec } from "vega-lite/build/src/spec";
+import { extractModifiedObjects ,removeUndefinedInSpec, fixVegaSpanBug, removeUnreferencedParams} from "./patchingUtils";
+import * as vl from "vega-lite";
+
+export class VegaPatchManager {
+    private spec: TopLevelSpec;
+    private modifiedElements: {data: any[], params: any[], scales: any[]};
+    constructor(spec: TopLevelSpec) {
+        this.spec = spec;
+
+        this.modifiedElements = extractModifiedObjects(spec);
+        //TODO CLENAUP:
+        //TODO stop from removing undefined with data
+        const undefinedRemoved = removeUndefinedInSpec(spec);
+        const unreferencedRemoved = removeUnreferencedParams(undefinedRemoved);
+
+        const newParams = fixVegaSpanBug(unreferencedRemoved.params)
+        unreferencedRemoved.params = newParams
+
+
+        // add reference to dataset
+        if(this.modifiedElements.data.length > 0){
+            unreferencedRemoved.datasets = unreferencedRemoved.datasets || {}
+            this.modifiedElements.data.forEach(dataset => {
+                console.log(`Added placeholder dataset: ${dataset.name}`);
+                unreferencedRemoved.datasets[dataset.name] = []
+            })
+        }
+
+        this.spec = unreferencedRemoved;
+
+
+    }
+
+    public compile(){
+        const vegaCompilation = vl.compile(this.spec);
+
+        console.log('vegaCompilation', vegaCompilation)
+        console.log('modifiedElements', this.modifiedElements)
+
+
+         // Update data elements that match modified elements
+         if (vegaCompilation.spec.data && this.modifiedElements.data && Array.isArray(this.modifiedElements.data) && this.modifiedElements.data.length > 0) {
+            vegaCompilation.spec.data = vegaCompilation.spec.data.map(dataElement => {
+                const matchingModifiedData = this.modifiedElements.data.find(
+                    modifiedData => modifiedData.name === dataElement.name
+                );
+                
+                if (matchingModifiedData) {
+                    console.log(`Updating data element: ${dataElement.name} with modified data`,matchingModifiedData);
+                    return matchingModifiedData ;
+                }
+                
+                return dataElement;
+            });
+            
+            // Move modified elements to the last position in the array
+            vegaCompilation.spec.data.sort((a, b) => {
+                const aIsModified = this.modifiedElements.data.some(d => d.name === a.name);
+                const bIsModified = this.modifiedElements.data.some(d => d.name === b.name);
+                if (aIsModified && !bIsModified) return 1;
+                if (!aIsModified && bIsModified) return -1;
+                return 0;
+            });
+        }
+
+        console.log('vegaCompilation.spec.data', vegaCompilation.spec.data)
+
+        // Update signals that match modified params
+        if (vegaCompilation.spec.signals && this.modifiedElements.params.length > 0) {
+            vegaCompilation.spec.signals = vegaCompilation.spec.signals.map(signal => {
+                const matchingParam = this.modifiedElements.params.find(
+                    param => param.name === signal.name
+                );
+                
+                if (matchingParam && matchingParam.on && signal.on) {
+                    console.log(`Merging signal handlers for: ${signal.name}`);
+                    // Create a new signal with merged 'on' arrays
+                    return {
+                        ...signal,
+                        on: [...signal.on, ...matchingParam.on]
+                    };
+                }
+                
+                return signal;
+            });
+        }
+        return vegaCompilation;
+    }
+    
+}

--- a/src/compilation/VegaPatchManager.ts
+++ b/src/compilation/VegaPatchManager.ts
@@ -13,13 +13,8 @@ export class VegaPatchManager {
         //TODO stop from removing undefined with data
         const undefinedRemoved = removeUndefinedInSpec(spec);
 
-        console.log('UNDEFINED REMOVED', JSON.parse(JSON.stringify(undefinedRemoved)))
         const unreferencedRemovedFirst = removeUnreferencedParams(undefinedRemoved);
         const unreferencedRemoved = removeUnreferencedParams(unreferencedRemovedFirst);
-
-
-        console.log('UNDEFINED REMOVED3',  JSON.parse(JSON.stringify(undefinedRemoved)),JSON.parse(JSON.stringify(unreferencedRemoved)),JSON.parse(JSON.stringify(unreferencedRemovedFirst)))
-
 
         const newParams = fixVegaSpanBug(unreferencedRemoved.params)
         unreferencedRemoved.params = newParams

--- a/src/compilation/VegaPatchManager.ts
+++ b/src/compilation/VegaPatchManager.ts
@@ -12,7 +12,11 @@ export class VegaPatchManager {
         //TODO CLENAUP:
         //TODO stop from removing undefined with data
         const undefinedRemoved = removeUndefinedInSpec(spec);
+
+        console.log('UNDEFINED REMOVED', JSON.parse(JSON.stringify(undefinedRemoved)))
         const unreferencedRemoved = removeUnreferencedParams(undefinedRemoved);
+        console.log('UNDEFINED REMOVED3', JSON.parse(JSON.stringify(unreferencedRemoved)))
+
 
         const newParams = fixVegaSpanBug(unreferencedRemoved.params)
         unreferencedRemoved.params = newParams

--- a/src/compilation/VegaPatchManager.ts
+++ b/src/compilation/VegaPatchManager.ts
@@ -14,8 +14,11 @@ export class VegaPatchManager {
         const undefinedRemoved = removeUndefinedInSpec(spec);
 
         console.log('UNDEFINED REMOVED', JSON.parse(JSON.stringify(undefinedRemoved)))
-        const unreferencedRemoved = removeUnreferencedParams(undefinedRemoved);
-        console.log('UNDEFINED REMOVED3', JSON.parse(JSON.stringify(unreferencedRemoved)))
+        const unreferencedRemovedFirst = removeUnreferencedParams(undefinedRemoved);
+        const unreferencedRemoved = removeUnreferencedParams(unreferencedRemovedFirst);
+
+
+        console.log('UNDEFINED REMOVED3',  JSON.parse(JSON.stringify(undefinedRemoved)),JSON.parse(JSON.stringify(unreferencedRemoved)),JSON.parse(JSON.stringify(unreferencedRemovedFirst)))
 
 
         const newParams = fixVegaSpanBug(unreferencedRemoved.params)

--- a/src/compilation/patchingUtils.ts
+++ b/src/compilation/patchingUtils.ts
@@ -124,10 +124,23 @@ export function removeUnreferencedParams(spec: TopLevelSpec) {
         // Count occurrences to ensure parameter is used at least twice
         const singleQuoteMatches = (specString.match(new RegExp(singleQuotePattern, 'g')) || []).length;
         const doubleQuoteMatches = (specString.match(new RegExp(doubleQuotePattern, 'g')) || []).length;
-        // const directRefMatches = (specString.match(directRefPattern) || []).length;
+        const directRefMatches = (specString.match(directRefPattern) || []).length;
         // console.log('directRefMatches', paramName, directRefMatches)
+        // Special case for debugging node_0_position_text parameter
+        if (paramName === "node_4_transform_data") {
+            const directRefPattern = new RegExp(`\\b${paramName}\\b`);
+            const directRefMatches = (specString.match(directRefPattern) || []).length;
+            
+            console.log('Parameter debugging:', {
+                paramName,
+                singleQuoteMatches,
+                doubleQuoteMatches,
+                directRefMatches,
+                specString: specString.substring(0, 200) + '...' // Show beginning of spec for context
+            });
+        }
 
-        const totalOccurrences = singleQuoteMatches + doubleQuoteMatches;// + directRefMatches;
+        const totalOccurrences = singleQuoteMatches + doubleQuoteMatches + directRefMatches;
         // console.log('directRefMatches total:', totalOccurrences, 'from:',directRefMatches, singleQuoteMatches, doubleQuoteMatches)
         return totalOccurrences >= 2;
     }) || [];

--- a/src/compilation/patchingUtils.ts
+++ b/src/compilation/patchingUtils.ts
@@ -122,23 +122,23 @@ export function removeUnreferencedParams(spec: TopLevelSpec) {
         const directRefPattern = new RegExp(`\\b${paramName}\\b`);
 
         // Count occurrences to ensure parameter is used at least twice
-        const singleQuoteMatches = (specString.match(new RegExp(singleQuotePattern, 'g')) || []).length;
-        const doubleQuoteMatches = (specString.match(new RegExp(doubleQuotePattern, 'g')) || []).length;
-        const directRefMatches = (specString.match(directRefPattern) || []).length;
+        // Create a copy of the string to avoid modifying the original
+        let tempString = specString;
+        
+        // Find and count single quote matches, then remove them from temp string
+        const singleQuoteRegex = new RegExp(singleQuotePattern, 'g');
+        const singleQuoteMatches = (tempString.match(singleQuoteRegex) || []).length;
+        tempString = tempString.replace(singleQuoteRegex, '');
+        
+        // Find and count double quote matches, then remove them from temp string
+        const doubleQuoteRegex = new RegExp(doubleQuotePattern, 'g');
+        const doubleQuoteMatches = (tempString.match(doubleQuoteRegex) || []).length;
+        tempString = tempString.replace(doubleQuoteRegex, '');
+        
+        // Finally count direct references in the remaining string
+        const directRefMatches = (tempString.match(directRefPattern) || []).length;
         // console.log('directRefMatches', paramName, directRefMatches)
-        // Special case for debugging node_0_position_text parameter
-        if (paramName === "node_4_transform_data") {
-            const directRefPattern = new RegExp(`\\b${paramName}\\b`);
-            const directRefMatches = (specString.match(directRefPattern) || []).length;
-            
-            console.log('Parameter debugging:', {
-                paramName,
-                singleQuoteMatches,
-                doubleQuoteMatches,
-                directRefMatches,
-                specString: specString.substring(0, 200) + '...' // Show beginning of spec for context
-            });
-        }
+       
 
         const totalOccurrences = singleQuoteMatches + doubleQuoteMatches + directRefMatches;
         // console.log('directRefMatches total:', totalOccurrences, 'from:',directRefMatches, singleQuoteMatches, doubleQuoteMatches)

--- a/src/compilation/patchingUtils.ts
+++ b/src/compilation/patchingUtils.ts
@@ -1,0 +1,238 @@
+import { extractAnchorType } from "../binding/cycles_CLEAN";
+import { TopLevelSpec } from "vega-lite/build/src/spec";
+import { TopLevelParameter } from "vega-lite/build/src/spec/toplevel";
+
+function stripVGXMOD(name: string) {
+    return name.replace('VGXMOD_', '')
+}
+
+type ModifiedElements = {
+    data: any[],
+    params: any[],
+    scales: any[]
+}
+export function extractModifiedObjects(spec: TopLevelSpec): ModifiedElements {
+    const result: ModifiedElements = { data: [], params: [], scales: []};
+
+    function extractDatasets(spec: any) {
+        if (spec.data && spec.data.name?.startsWith('VGXMOD_')) {
+            const datasets = (Array.isArray(spec.data) ? spec.data : [spec.data]).map(dataset => ({
+                ...dataset,
+                name: stripVGXMOD(dataset.name)
+            }));
+
+            // result.data = result.data || [];
+            result.data.push(...datasets);
+            spec.data = {
+                name: stripVGXMOD(spec.data.name),
+            }
+        }
+    }
+
+    function extractParams(spec: any) {
+        if (spec.params) {
+            spec.params=spec.params.filter(param => {
+                if (param.name?.startsWith('VGXMOD_')) {
+                    result.params.push({
+                        ...param,
+                        name: stripVGXMOD(param.name)
+                    });
+                    return false;
+                }
+                return true;
+            })
+
+            // const params = (Array.isArray(spec.params) ? spec.params : [spec.params]).map(param => ({
+            //     ...param,
+            //     name: stripVGXMOD(param.name)
+            // }));
+            // // result.params = result.params || [];
+            // result.params.push(...params);
+        }
+    }
+    
+    // Helper function to recursively extract datasets from nested specs
+    function extractFromSpec(currentSpec: any, extractorFn: (spec: any) => void) {
+
+        extractorFn(currentSpec)
+        
+    
+
+        
+        // Check in layers
+        if (currentSpec.layer) {
+            for (const layer of currentSpec.layer) {
+                extractFromSpec(layer, extractorFn);
+            }
+        }
+        
+        // Check in hconcat
+        if (currentSpec.hconcat) {
+            for (const view of currentSpec.hconcat) {
+                extractFromSpec(view, extractorFn);
+            }
+        }
+        
+        // Check in vconcat
+        if (currentSpec.vconcat) {
+            for (const view of currentSpec.vconcat) {
+                extractFromSpec(view, extractorFn);
+            }
+        }
+        
+        // Check in concat
+        if (currentSpec.concat) {
+            for (const view of currentSpec.concat) {
+                extractFromSpec(view, extractorFn);
+            }
+        }
+    }
+
+   
+
+    extractFromSpec(spec, extractDatasets);
+    extractFromSpec(spec, extractParams);
+    return result;
+}
+
+
+
+export function removeUnreferencedParams(spec: TopLevelSpec) {
+    // Stringify the spec (omitting data) to search for parameter usage
+    const specString = JSON.stringify(spec, (key, value) => {
+        // Skip data values to reduce size
+        if (key === 'values' && Array.isArray(value)) {
+            return '[...]';
+        }
+        return value;
+    });
+
+    // Check if each parameter is actually used in expressions
+    const usedParams = spec.params?.filter(param => {
+        const paramName = param.name;
+        if (paramName.includes('VGXMOD_')) {
+            return true;
+        }
+        // Look for the parameter name within expression strings
+        // Match both 'paramName' and "paramName" patterns
+        const singleQuotePattern = `'${paramName}'`;
+        const doubleQuotePattern = `"${paramName}"`;
+
+        // Also match direct references to the parameter in expressions
+        const directRefPattern = new RegExp(`\\b${paramName}\\b`);
+
+        // Count occurrences to ensure parameter is used at least twice
+        const singleQuoteMatches = (specString.match(new RegExp(singleQuotePattern, 'g')) || []).length;
+        const doubleQuoteMatches = (specString.match(new RegExp(doubleQuotePattern, 'g')) || []).length;
+        // const directRefMatches = (specString.match(directRefPattern) || []).length;
+        // console.log('directRefMatches', paramName, directRefMatches)
+
+        const totalOccurrences = singleQuoteMatches + doubleQuoteMatches;// + directRefMatches;
+        // console.log('directRefMatches total:', totalOccurrences, 'from:',directRefMatches, singleQuoteMatches, doubleQuoteMatches)
+        return totalOccurrences >= 2;
+    }) || [];
+
+    return {
+        ...spec,
+        params: usedParams
+    }
+}
+export function removeUndefinedInSpec(obj: TopLevelSpec): TopLevelSpec {
+    if (!obj || typeof obj !== 'object') {
+        return obj;
+    }
+
+    if (Array.isArray(obj)) {
+        return obj.map(item => removeUndefinedInSpec(item)).filter(item => item !== undefined) as any;
+    }
+
+    const result: any = {};
+    for (const [key, value] of Object.entries(obj)) {
+        if (value === undefined) continue;
+
+        const cleanValue = removeUndefinedInSpec(value);
+        if (cleanValue !== undefined) {
+            result[key] = cleanValue;
+        }
+    }
+    return result;
+}
+
+
+
+/*
+
+ Temporary fix for the issue where start span parameters don't seem to update?
+ Looks like it isn't detecting changing with node_start, and thus it doesn't update it, even when 
+ a new drag occurs. 
+
+*/
+export function fixVegaSpanBug(params: TopLevelParameter[]) :TopLevelParameter[]{
+    for (let i = 0; i < params.length; i++) {
+        const param = params[i];
+        
+        
+        // Check if this is a span start parameter for any dimension (x or y)
+        if (param.name.endsWith('_x_start') || param.name.endsWith('_y_start') || 
+            param.name.endsWith('begin_x') || param.name.endsWith('begin_y')) {
+         
+            // Extract the dimension from the parameter name
+            let dimension, startType;
+            
+            if (param.name.endsWith('_x_start') || param.name.endsWith('_y_start')) {
+                dimension = param.name.endsWith('_x_start') ? 'x' : 'y';
+                startType = 'start';
+            } else if (param.name.endsWith('_begin_x') || param.name.endsWith('_begin_y')) {
+                dimension = param.name.endsWith('_begin_x') ? 'x' : 'y';
+                startType = 'begin';
+            } else {
+                // Fallback to extracting channel if the pattern doesn't match
+                const channel = extractAnchorType(param.name);
+                dimension = channel === 'x' ? 'x' : 'y';
+                startType = param.name.includes('_start') ? 'start' : 'begin';
+            }
+
+            const baseName = startType === 'start' ? 
+                param.name.split(`_${dimension}_start`)[0] : 
+                param.name.split(`_begin_${dimension}`)[0];
+            
+            // Find the corresponding stop parameter
+            const stopParamName = baseName + (startType === 'start' ? `_${dimension}_stop` : `_point_${dimension}`);
+            // Find the corresponding stop parameter
+            // const stopParamName = `${nodeId}_span_${dimension}_stop`;
+            
+            // Ensure the param has an 'on' array
+            if (!param.on) {
+                param.on = [];
+            }
+            
+            // If there's already an event handler, add to it
+            if (param.on.length > 0) {
+                // Add the stop parameter to the events if it's not already there
+                if (!param.on[0].events.signal || !param.on[0].events.signal.includes(stopParamName)) {
+                    if (!Array.isArray(param.on[0].events)) {
+                        const pastObject = param.on[0].events;
+
+                        param.on[0].events = [ { signal: stopParamName }];
+                        if (pastObject) {
+                            param.on[0].events.push(pastObject);
+                        }
+                        
+                    } else {
+                        param.on[0].events.push({signal:stopParamName});
+
+                       
+                    }
+                }
+            } else {
+                // A scale parameter doesn't have an on array
+                // // Create a new event handler
+                // param.on.push({
+                //     events: { signal: stopParamName },
+                //     update: param.update || param.value
+                // });
+            }
+        }
+    }
+    return params;
+}

--- a/src/components/DataAccessor.ts
+++ b/src/components/DataAccessor.ts
@@ -1,0 +1,99 @@
+import { BaseComponent } from "../components/base";
+
+type DataOperation = {
+  type: 'filter' | 'aggregate' | 'groupby' | 'count' | 'percent';
+  params: any;
+};
+
+export class DataAccessor {
+  private sourceComponent: BaseComponent;
+  private operations: DataOperation[] = [];
+  private selectionName: string;
+  
+  constructor(sourceComponent: BaseComponent, selectionName?: string) {
+    this.sourceComponent = sourceComponent;
+    this.selectionName = selectionName || sourceComponent.id;
+  }
+
+  // Basic operations
+  filter(expr: string): DataAccessor {
+    this.operations.push({ type: 'filter', params: { expr } });
+    return this;
+  }
+
+  groupby(...fields: string[]): DataAccessor {
+    this.operations.push({ type: 'groupby', params: { fields } });
+    return this;
+  }
+
+  // Aggregation method
+  count(): DataAccessor {
+    this.operations.push({ 
+      type: 'count', 
+      params: { as: 'count' } 
+    });
+    return this;
+  }
+
+  // Getter for percentage of total data
+  get percent(): DataAccessor {
+    this.operations.push({
+      type: 'percent',
+      params: { as: 'percent' }
+    });
+    return this;
+  }
+
+  // Method to get a reference to this data
+  getReference(): string {
+    return `${this.selectionName}_data`;
+  }
+
+  // Method to compile into VL transforms
+  compileToTransforms(): any[] {
+    const transforms = [];
+    
+    // Start with the selection filter
+    transforms.push({
+      filter: { selection: this.selectionName }
+    });
+    
+    // Process operations
+    let needsAggregate = false;
+    let aggregateOps = [];
+    let groupbyFields = [];
+    
+    for (const op of this.operations) {
+      switch (op.type) {
+        case 'filter':
+          transforms.push({ filter: op.params.expr });
+          break;
+        case 'groupby':
+          groupbyFields = op.params.fields;
+          needsAggregate = true;
+          break;
+        case 'count':
+          aggregateOps.push({ op: 'count', as: op.params.as });
+          needsAggregate = true;
+          break;
+        case 'percent':
+          // This needs to be added after aggregation
+          transforms.push({
+            calculate: "datum.count / parent.count", 
+            as: "percent"
+          });
+          break;
+      }
+    }
+    
+    // Add aggregate transform if needed
+    if (needsAggregate) {
+      transforms.push({
+        aggregate: aggregateOps,
+        ...(groupbyFields.length > 0 && { groupby: groupbyFields })
+      });
+    }
+    
+    return transforms;
+  }
+}

--- a/src/components/DataAccessor.ts
+++ b/src/components/DataAccessor.ts
@@ -2,6 +2,7 @@ import { BaseComponent } from "./base";
 import { UnitSpec } from "vega-lite/build/src/spec";
 import { Field } from "vega-lite/build/src/channeldef";
 import { generateConfigurationAnchors } from "./interactions/drag2";
+import { LazyOperation } from "../binding/LazyBinding";
 
 type DataOperation = {
   type: 'filter' | 'aggregate' | 'groupby' | 'count' | 'percent';
@@ -138,8 +139,8 @@ class DataTransformer extends BaseComponent {
     const transforms = this.compileToTransforms();
     
     return {
-      "dataAccessor":{
-        datasetName:this.id +"_transform_data",
+      "data":{
+        name: "VGXMOD_"+this.id +"_transform_data",
         transform: transforms,
         source: "baseChartData"
       }
@@ -257,6 +258,18 @@ export class DataAccessor {
     });
     return this;
   }
+
+
+  // Used to apply operations to data transforms if referenced before initialization
+   public applyOperations(accessor: any, operations: LazyOperation[]){
+    let value = accessor;
+    for (const op of operations) {
+        if (value && value[op.type]) {
+            value = value[op.type](...op.args);
+        }
+    }
+    return value;
+}
   
   // Convert to a component at the end of chaining
   toComponent(): BaseComponent {

--- a/src/components/DataAccessor.ts
+++ b/src/components/DataAccessor.ts
@@ -90,7 +90,6 @@ class DataTransformer extends BaseComponent {
 
       
 
-      console.log('dataAnchor', this.anchors.get('transform_data'))
     
     // Setup basic anchors
     // this.setupAnchors();
@@ -134,7 +133,6 @@ class DataTransformer extends BaseComponent {
   }
   
   compileComponent(inputContext: any): Partial<UnitSpec<Field>> {
-    console.log('compiging data accessor', inputContext)
     // Add data transforms to the chart
     const transforms = this.compileToTransforms();
     
@@ -202,7 +200,6 @@ class DataTransformer extends BaseComponent {
           break;
       }
     }
-    console.log('transformsCompiled', transforms)
     
     // Add aggregate transform if needed
     if (needsAggregate) {
@@ -242,7 +239,6 @@ export class DataAccessor {
 
   // Aggregation method
   count(): DataAccessor {
-    console.log('PUSHING COUNT', this.sourceComponent.id)
     this.operations.push({ 
       type: 'count', 
       params: { as: 'count' } 

--- a/src/components/DataAccessor.ts
+++ b/src/components/DataAccessor.ts
@@ -20,7 +20,7 @@ const configurations = [{
             valueType: "Numeric"
           },
           "text": { 
-            container: 'Scalar',
+            container: 'Data',
             valueType: "Categorical"
           }
        
@@ -62,75 +62,8 @@ class DataTransformer extends BaseComponent {
         //     return generateConfigurationAnchors(this.id, config.id)
         // }));
     });
-
-
-
-    
-   
-    // this.anchors.set('data', this.createAnchorProxy({ 
-    //     'data': { 
-    //       container: 'Data',
-    //       valueType: "Numeric"
-    //     }
-    //   }, 'data', () => {
-    //     return 
-
-    //   }));
-
-    //   this.anchors.set('text', this.createAnchorProxy({ 
-    //     'text': { 
-    //       container: 'Scalar',
-    //       valueType: "Categorical"
-    //     }
-    //   }, 'text', () => {
-
-    //     return "datum.count";
-
-    //   }));
-
-      
-
-    
-    // Setup basic anchors
-    // this.setupAnchors();
   }
   
-  private setupAnchors() {
-    // Always set up count anchor regardless of operations
-    this.anchors.set('count', this.createAnchorProxy({ 
-      'count': { 
-        container: 'Scalar',
-        valueType: 'Numeric',
-      }
-    }, 'count', () => {
-      return { 'value': `datum.count` };
-    }));
-
-    // Always set up percent anchor
-    this.anchors.set('percent', this.createAnchorProxy({ 
-      'percent': { 
-        container: 'Scalar',
-        valueType: 'Numeric',
-      }
-    }, 'percent', () => {
-      return { 'value': `datum.count` }; // Using count for now
-    }));
-    
-    // // Setup anchors for each field in groupby operations
-    // const groupbyOps = this.operations.filter(op => op.type === 'groupby');
-    // groupbyOps.forEach(op => {
-    //   op.params.fields.forEach((field: string) => {
-    //     this.anchors.set(field, this.createAnchorProxy({ 
-    //       [field]: { 
-    //         container: 'Scalar',
-    //         valueType: 'Categorical',
-    //       }
-    //     }, field, () => {
-    //       return { 'value': `datum.count` }; // Using count for now
-    //     }));
-    //   });
-    // });
-  }
   
   compileComponent(inputContext: any): Partial<UnitSpec<Field>> {
     // Add data transforms to the chart
@@ -141,7 +74,14 @@ class DataTransformer extends BaseComponent {
         name: "VGXMOD_"+this.id +"_transform_data",
         transform: transforms,
         source: "baseChartData"
-      }
+      },
+      "params": [
+        //@ts-ignore
+        {
+          "name":this.id +"_transform_text",
+          "value":"count", // the name of the field to read data from
+        }
+      ]
     };
   }
   

--- a/src/components/DataAccessor.ts
+++ b/src/components/DataAccessor.ts
@@ -17,6 +17,19 @@ class DataTransformer extends BaseComponent {
     this.sourceSelectionName = sourceComponent.id;
     this.operations = [...operations]; // Clone the operations
     
+    console.log('sourceComponentData', sourceComponent)
+
+    this.anchors.set('data', this.createAnchorProxy({ 
+        'data': { 
+          container: 'Data',
+          valueType: 'Data',
+        }
+      }, 'data', () => {
+        return { 'value': `${this.sourceSelectionName}`, 'field': 'count' };
+
+      }));
+    
+      console.log('data anchor', this.anchors.get('data'))
     // Setup basic anchors
     // this.setupAnchors();
   }
@@ -32,15 +45,6 @@ class DataTransformer extends BaseComponent {
       return { 'value': `datum.count` };
     }));
 
-    this.anchors.set('data', this.createAnchorProxy({ 
-        'data': { 
-          container: 'Data',
-          valueType: 'Data',
-        }
-      }, 'count', () => {
-        return { 'value': `datum.count` };
-      }));
-    
     // Always set up percent anchor
     this.anchors.set('percent', this.createAnchorProxy({ 
       'percent': { 

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -62,12 +62,10 @@ export abstract class BaseComponent {
 
     bindings.forEach(({ value: binding, key }) => {
 
-      console.log("INGETTINGBINDINGS",binding, key)
       const bindingProperty = key.includes('.') ? key.split('.')[1] : (isAllBind(key) ? '_all' : key);
 
 
       if(binding.isLazy){
-        console.log("LAZYBINDING",binding,binding.id)
         this.bindingManager.addBinding(this.id, binding.id, bindingProperty, '_all');
         return;
       }
@@ -213,7 +211,6 @@ export abstract class BaseComponent {
 const findBindings = (value: any, path: string = ''): { value: BaseComponent | AnchorProxy | LazyComponent, key: string }[] => {
   if (!value) return [];
 
-  console.log("FINDINGBINDINGS",value, path)
   // Handle arrays, but skip if path is 'data'
   if (Array.isArray(value)) {
     return value.flatMap((item, index) => findBindings(item, `${path}[${index}]`));
@@ -223,13 +220,11 @@ const findBindings = (value: any, path: string = ''): { value: BaseComponent | A
   if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
     const lazyBindings = [];
     for (const prop in value) {
-      console.log('checking', prop, 'valueprop:',value[prop],value[prop].isLazy)
       if (value[prop] && value[prop].isLazy) {
         lazyBindings.push({ value: value[prop], key: prop });
       }
     }
     if (lazyBindings.length > 0) {
-      console.log("non-zeroLAZYBINDINGS",lazyBindings)
       return lazyBindings;
     }
   }

--- a/src/components/base.ts
+++ b/src/components/base.ts
@@ -53,7 +53,6 @@ export abstract class BaseComponent {
     function getTargetId(binding: BaseComponent | AnchorProxy): string {
       return isComponent(binding) ? binding.id : (binding as AnchorProxy).id.componentId;
     }
-    console.log('bindings', bindings)
     function isAllBind(key:string){
       return key === 'bind' || (/^bind\[\d+\]$/.test(key) && !key.includes('.'))
     }
@@ -61,7 +60,6 @@ export abstract class BaseComponent {
 
     bindings.forEach(({ value: binding, key }) => {
       const bindingProperty = key.includes('.') ? key.split('.')[1] : (isAllBind(key) ? '_all' : key);
-      console.log('bindingProperty',bindingProperty)
 
       // TODO interactive binding reversal– this may be not needed depending on how scalar:scalar is handled
       if(bindingProperty === '_all'){

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -4,7 +4,7 @@ import { BaseComponent } from "../../base";
 import { extractAllNodeNames, generateSignal, generateSignalsFromTransforms } from "../../utils";
 import { UnitSpec } from "vega-lite/build/src/spec";
 import { Field } from "vega-lite/build/src/channeldef";
-
+import { DataAccessor } from "../../DataAccessor";
 export class BrushConstructor {
     id: string;
     constructor(config: any) {
@@ -94,9 +94,11 @@ const configurations = [{
 
 
 export class Brush extends BaseComponent {
+    _data: DataAccessor;
     constructor(config: any = {}) {
         super(config);
         console.log('constructing brush', this, config)
+        this._data = new DataAccessor(this);
         configurations.forEach(config => {
             this.configurations[config.id] = config
             const schema = config.schema
@@ -111,16 +113,24 @@ export class Brush extends BaseComponent {
                     return generatedAnchor
                 }));
             }
-            // this.anchors.set(config.id, this.createAnchorProxy({[config.id]: config.schema[config.id]}, config.id, () => {
-            //     return generateConfigurationAnchors(this.id, config.id)
-            // }));
         });
-        // this.anchors.set('x', this.createAnchorProxy({ 'x': this.schema['x'] }, 'x', () => {
-        //     return { 'value': generateCompiledValue(this.id, 'x') }
-        // }));
+
+        // Add data as an anchor
+        this.anchors.set('data', this.createAnchorProxy({ 
+            'data': { 
+            container: 'Data',
+            valueType: 'Data',
+            }
+        }, 'data', () => {
+            return { 'value': this._data };
+        }));
 
 
-
+    }
+        // Getter for data accessor
+    get data(): DataAccessor {
+        console.log('getting data', this._data)
+        return new DataAccessor(this);
     }
 
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -39,7 +39,6 @@ export class BrushConstructor {
         
         // Get all components that need to be bound
         const allBindings = extractComponentBindings(config);
-        console.log('allBindings', allBindings)
 
         
 
@@ -71,9 +70,7 @@ export class BrushConstructor {
 
         const bindingManager = BindingManager.getInstance();
 
-        console.log('pre dragProxy',bindingManager.getComponents())
         bindingManager.removeComponent(drag.id);
-        console.log('adding dragProxy',bindingManager.getComponents())
         bindingManager.addComponent(dragProxy);
         
         // Return the proxy instead of the original drag object
@@ -99,10 +96,7 @@ const configurations = [{
             "valueType": "Numeric",
             // "interactive": true // TODO add back in when it won't screw with the chart domains
         },
-        "data": {
-            "container": "Data",
-            "valueType": "Data",
-        }
+       
 
     },
     "transforms": [{
@@ -161,17 +155,13 @@ export class Brush extends BaseComponent {
     
         // Getter for data accessor
     get data(): DataAccessor {
-        console.log('getting data', this._data)
         const accessor= new DataAccessor(this);
         this.accessors.push(accessor);
-        console.log('accessor', accessor)
         return accessor.filter(`vlSelectionTest(${this.id}_store, datum)`)
     }
 
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {
-        console.log('compiling brush', this, inputContext)
         const nodeId = inputContext.nodeId || this.id;
-        console.log('inputContextDRAG', inputContext, nodeId)
         const markName = inputContext['point_markName']?.[0] ? inputContext['point_markName'][0] + "_marks" : '';
         const selection = {
             "name": this.id,
@@ -185,7 +175,6 @@ export class Brush extends BaseComponent {
             }
         }
 
-        console.log('compiling accessors', this.accessors)
 
         const xNodeStart = extractAllNodeNames(inputContext['interval_x'].find(constraint => constraint.includes('start')))[0]
         const xNodeStop = extractAllNodeNames(inputContext['interval_x'].find(constraint => constraint.includes('stop')))[1]
@@ -193,7 +182,6 @@ export class Brush extends BaseComponent {
         const yNodeStart = extractAllNodeNames(inputContext['interval_y'].find(constraint => constraint.includes('start')))[0]
         const yNodeStop = extractAllNodeNames(inputContext['interval_y'].find(constraint => constraint.includes('stop')))[1]
 
-        console.log('xNodes', xNodeStart, xNodeStop, 'yNodes', yNodeStart, yNodeStop)
 
 
         const selectionModifications = [{"name":"VGXMOD_"+this.id+"_x","on":[{"events":[{"signal":xNodeStart},{"signal":xNodeStop}],"update":`[${xNodeStart},${xNodeStop}]`}]},

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -34,7 +34,6 @@ export class BrushConstructor {
                 return [config.bind, ...extractComponentBindings(config.bind)];
             }
             
-            console.log('config.bind', config.bind)
             // If bind is a single object without further bindings
             return [config.bind];
         };
@@ -49,7 +48,6 @@ export class BrushConstructor {
         this.id = brush.id;
 
         const drag = new CombinedDrag({ bind: [...allBindings,{ span: new Rect({ "strokeDash": [6, 4],'stroke':'firebrick','strokeWidth':2,'strokeOpacity':0.7,'fillOpacity':0.2,'fill':'firebrick'}) },brush] });
-        console.log('made drag!')
 
 
         // const brush = new Brush({ bind: drag });

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -111,6 +111,35 @@ const configurations = [{
         "value": "PARENT_ID.y" // replace the parent id + get the channel value
     }
     ]
+},
+{// STIL BROKEN
+    'id': 'top',
+    "schema": {
+        "x": {
+            "container": "Scalar",
+            "valueType": "Numeric",
+            // "interactive": true
+        },
+        "y": {
+            "container": "Scalar",
+            "valueType": "Numeric",
+            // "interactive": true // TODO add back in when it won't screw with the chart domains
+        },
+      
+       
+
+    },
+    "transforms": [{
+        "name": "x",
+        "channel": "x",
+        "value": "PARENT_ID.x" // replace the parent id + get the channel value
+    },
+    {
+        "name": "y",
+        "channel": "y",
+        "value": "PARENT_ID.y" // replace the parent id + get the channel value
+    }
+    ]
 }]
 
 
@@ -188,69 +217,7 @@ export class Brush extends BaseComponent {
         const selectionModifications = [{"name":"VGXMOD_"+this.id+"_x","on":[{"events":[{"signal":xNodeStart},{"signal":xNodeStop}],"update":`[${xNodeStart},${xNodeStop}]`}]},
                                         {"name":"VGXMOD_"+this.id+"_y","on":[{"events":[{"signal":yNodeStart},{"signal":yNodeStop}],"update":`[${yNodeStart},${yNodeStop}]`}]}]
 
-        // const signal = {
-        //     name: this.id, // base signal
-        //     value: dragBaseContext,
-        //     on: [{ events: { type: 'pointerdown', 'markname': markName }, update: `{'start': {'x': x(), 'y': y()}}` },
-        //     {
-        //         events: {
-        //             type: 'pointermove',
-        //             source: "window",
-        //             between: [
-        //                 { type: "pointerdown", "markname": markName },
-        //                 { type: "pointerup", source: "window", }
-        //             ]
-        //         },
-        //         update: `merge(${nodeId}, {'x': x(), 'y': y(),  'stop': {'x': x(), 'y': y()}})`
-        //     }]
-        // };
-
-
-
-
-
-        // // Generate all signals
-        // const outputSignals = Object.values(this.configurations)
-        //     .filter(config => Array.isArray(config.transforms)) // Make sure transforms exist
-        //     .flatMap(config => {
-        //         // Build constraint map from inputContext
-        //         const constraintMap = {};
-        //         Object.keys(config.schema).forEach(channel => {
-        //             const key = `${config.id}_${channel}`;
-        //             constraintMap[channel] = inputContext[key] || [];
-        //         });
-
-        //         const signalPrefix = this.id + '_' + config.id
-        //         // Generate signals for this configuratio
-
-
-        //         return generateSignalsFromTransforms(
-        //             config.transforms,
-        //             nodeId,
-        //             signalPrefix,
-        //             constraintMap
-        //         );
-        //     });
-        // // Additional signals can be added here and will be av  ilable in input contexts
-        // const internalSignals = [...this.anchors.keys()]
-        //     .filter(key => key.endsWith('_internal'))
-        //     .map(key => {
-        //         //no need to get constraints as constraints would have had it be already
-        //         // get the transform 
-        //         const config = this.configurations[key.split('_')[0]];
-
-        //         const compatibleTransforms = config.transforms.filter(transform => transform.channel === key.split('_')[1])
-
-
-        //         return compatibleTransforms.map(transform => generateSignal({
-        //             id: nodeId,
-        //             transform: transform,
-        //             output: nodeId + '_' + key,
-        //             constraints: ["VGX_SIGNAL_NAME"]
-        //         }))
-        //     }
-
-        //     ).flat();
+        
         return {
             params: [selection, ...selectionModifications]
         }

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -6,7 +6,9 @@ import { UnitSpec } from "vega-lite/build/src/spec";
 import { Field } from "vega-lite/build/src/channeldef";
 
 export class BrushConstructor {
+    id: string;
     constructor(config: any) {
+      
 
         
         // Extract all components from config and their bindings
@@ -41,16 +43,17 @@ export class BrushConstructor {
         const allBindings = extractComponentBindings(config);
         console.log('allBindings', allBindings)
 
+        
 
-        const drag = new CombinedDrag({ bind: [...allBindings,{ span: new Rect({ "strokeDash": [6, 4],'stroke':'firebrick','strokeWidth':2,'strokeOpacity':0.7,'fillOpacity':0.2,'fill':'firebrick'}) },new Brush({})] });
+        const brush = new Brush(config);
+        this.id = brush.id;
+
+        const drag = new CombinedDrag({ bind: [...allBindings,{ span: new Rect({ "strokeDash": [6, 4],'stroke':'firebrick','strokeWidth':2,'strokeOpacity':0.7,'fillOpacity':0.2,'fill':'firebrick'}) },brush] });
         console.log('made drag!')
 
 
         // const brush = new Brush({ bind: drag });
         // console.log('passing through brush', brush, drag)
-
-
-
 
         return drag; // pass through to the drag component, but still have parent edges via brush bind.
     }

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -52,6 +52,21 @@ export class BrushConstructor {
 
         // const brush = new Brush({ bind: drag });
         // console.log('passing through brush', brush, drag)
+        // Create a proxy to intercept property access on drag
+        const dragProxy = new Proxy(drag, {
+            get(target, prop, receiver) {
+                // If accessing 'data' property, redirect to brush.data
+                if (prop === 'data') {
+                    return brush._data;
+                }
+                
+                // For all other properties, use the original drag object
+                return Reflect.get(target, prop, receiver);
+            }
+        });
+        
+        // Return the proxy instead of the original drag object
+        return dragProxy;
 
         return drag; // pass through to the drag component, but still have parent edges via brush bind.
     }
@@ -132,7 +147,9 @@ export class Brush extends BaseComponent {
         // Getter for data accessor
     get data(): DataAccessor {
         console.log('getting data', this._data)
-        return new DataAccessor(this);
+        const accessor= new DataAccessor(this);
+        console.log('accessor', accessor)
+        return accessor.filter(`vlSelectionTest(${this.id}_store, datum)`)
     }
 
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -96,9 +96,6 @@ const configurations = [{
             "valueType": "Numeric",
             // "interactive": true // TODO add back in when it won't screw with the chart domains
         },
-      
-       
-
     },
     "transforms": [
     //     {
@@ -111,6 +108,7 @@ const configurations = [{
     //     "channel": "y",
     //     "value": "PARENT_ID.y" // replace the parent id + get the channel value
     // } 
+    //BROKEN, but not used for signals rn
     { "name": "x_start", "channel": "x", "value": "PARENT_ID_x[0]" },
     { "name": "x_stop", "channel": "x", "value": "PARENT_ID_x[1]" },
     { "name": "y_start", "channel": "y", "value": "50" },
@@ -163,7 +161,6 @@ export class Brush extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -8,8 +8,6 @@ import { DataAccessor } from "../../DataAccessor";
 export class BrushConstructor {
     id: string;
     constructor(config: any) {
-      
-
         
         // Extract all components from config and their bindings
         const extractComponentBindings = (config: any): any[] => {
@@ -58,6 +56,9 @@ export class BrushConstructor {
                 // If accessing 'data' property, redirect to brush.data
                 if (prop === 'data') {
                     return brush._data;
+                }
+                if (prop === 'brush') {
+                    return brush;
                 }
                 
                 // For all other properties, use the original drag object
@@ -110,10 +111,12 @@ const configurations = [{
 
 export class Brush extends BaseComponent {
     _data: DataAccessor;
+    accessors: DataAccessor[];
     constructor(config: any = {}) {
         super(config);
         console.log('constructing brush', this, config)
         this._data = new DataAccessor(this);
+        this.accessors = [];
         configurations.forEach(config => {
             this.configurations[config.id] = config
             const schema = config.schema
@@ -144,10 +147,13 @@ export class Brush extends BaseComponent {
 
 
     }
+
+    
         // Getter for data accessor
     get data(): DataAccessor {
         console.log('getting data', this._data)
         const accessor= new DataAccessor(this);
+        this.accessors.push(accessor);
         console.log('accessor', accessor)
         return accessor.filter(`vlSelectionTest(${this.id}_store, datum)`)
     }
@@ -168,6 +174,8 @@ export class Brush extends BaseComponent {
                 }
             }
         }
+
+        console.log('compiling accessors', this.accessors)
 
         const xNodeStart = extractAllNodeNames(inputContext['interval_x'].find(constraint => constraint.includes('start')))[0]
         const xNodeStop = extractAllNodeNames(inputContext['interval_x'].find(constraint => constraint.includes('stop')))[1]

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -148,7 +148,6 @@ export class Brush extends BaseComponent {
     accessors: DataAccessor[];
     constructor(config: any = {}) {
         super(config);
-        console.log('constructing brush', this, config)
         this._data = new DataAccessor(this);
         this.accessors = [];
         configurations.forEach(config => {

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -5,6 +5,7 @@ import { extractAllNodeNames, generateSignal, generateSignalsFromTransforms } fr
 import { UnitSpec } from "vega-lite/build/src/spec";
 import { Field } from "vega-lite/build/src/channeldef";
 import { DataAccessor } from "../../DataAccessor";
+import { BindingManager } from "../../../binding/BindingManager";
 export class BrushConstructor {
     id: string;
     constructor(config: any) {
@@ -43,6 +44,8 @@ export class BrushConstructor {
         
 
         const brush = new Brush(config);
+        
+
         this.id = brush.id;
 
         const drag = new CombinedDrag({ bind: [...allBindings,{ span: new Rect({ "strokeDash": [6, 4],'stroke':'firebrick','strokeWidth':2,'strokeOpacity':0.7,'fillOpacity':0.2,'fill':'firebrick'}) },brush] });
@@ -65,6 +68,13 @@ export class BrushConstructor {
                 return Reflect.get(target, prop, receiver);
             }
         });
+
+        const bindingManager = BindingManager.getInstance();
+
+        console.log('pre dragProxy',bindingManager.getComponents())
+        bindingManager.removeComponent(drag.id);
+        console.log('adding dragProxy',bindingManager.getComponents())
+        bindingManager.addComponent(dragProxy);
         
         // Return the proxy instead of the original drag object
         return dragProxy;

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -115,6 +115,8 @@ export class Brush extends BaseComponent {
             }
         });
 
+        this._data.filter(`vlSelectionTest(${this.id}_store, datum)`)// any data referenced from the brush will be filtered
+
         // Add data as an anchor
         this.anchors.set('data', this.createAnchorProxy({ 
             'data': { 

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -96,6 +96,7 @@ const configurations = [{
             "valueType": "Numeric",
             // "interactive": true // TODO add back in when it won't screw with the chart domains
         },
+      
        
 
     },
@@ -139,15 +140,15 @@ export class Brush extends BaseComponent {
 
         this._data.filter(`vlSelectionTest(${this.id}_store, datum)`)// any data referenced from the brush will be filtered
 
-        // Add data as an anchor
-        this.anchors.set('data', this.createAnchorProxy({ 
-            'data': { 
-            container: 'Data',
-            valueType: 'Data',
-            }
-        }, 'data', () => {
-            return { 'value': this._data };
-        }));
+        // // Add data as an anchor
+        // this.anchors.set('data', this.createAnchorProxy({ 
+        //     'data': { 
+        //     container: 'Data',
+        //     valueType: 'Data',
+        //     }
+        // }, 'data', () => {
+        //     return { 'value': this._data };
+        // }));
 
 
     }

--- a/src/components/interactions/Instruments/Brush.ts
+++ b/src/components/interactions/Instruments/Brush.ts
@@ -100,16 +100,21 @@ const configurations = [{
        
 
     },
-    "transforms": [{
-        "name": "x",
-        "channel": "x",
-        "value": "PARENT_ID.x" // replace the parent id + get the channel value
-    },
-    {
-        "name": "y",
-        "channel": "y",
-        "value": "PARENT_ID.y" // replace the parent id + get the channel value
-    }
+    "transforms": [
+    //     {
+    //     "name": "x",
+    //     "channel": "x",
+    //     "value": "PARENT_ID.x" // replace the parent id + get the channel value
+    // },
+    // {
+    //     "name": "y",
+    //     "channel": "y",
+    //     "value": "PARENT_ID.y" // replace the parent id + get the channel value
+    // } 
+    { "name": "x_start", "channel": "x", "value": "PARENT_ID_x[0]" },
+    { "name": "x_stop", "channel": "x", "value": "PARENT_ID_x[1]" },
+    { "name": "y_start", "channel": "y", "value": "50" },
+    // { "name": "y_stop", "channel": "y", "value": "PARENT_ID.stop.y" },
     ]
 },
 {// STIL BROKEN
@@ -125,19 +130,16 @@ const configurations = [{
             "valueType": "Numeric",
             // "interactive": true // TODO add back in when it won't screw with the chart domains
         },
-      
-       
-
     },
     "transforms": [{
         "name": "x",
         "channel": "x",
-        "value": "PARENT_ID.x" // replace the parent id + get the channel value
+        "value": "(PARENT_ID_interval_x_start+PARENT_ID_interval_x_stop)/2" // replace the parent id + get the channel value
     },
     {
         "name": "y",
         "channel": "y",
-        "value": "PARENT_ID.y" // replace the parent id + get the channel value
+        "value": "PARENT_ID_interval_y_start" // replace the parent id + get the channel value
     }
     ]
 }]
@@ -161,6 +163,7 @@ export class Brush extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }
@@ -203,6 +206,34 @@ export class Brush extends BaseComponent {
                 }
             }
         }
+
+        // // Generate all signals
+        // const outputSignals = Object.values(this.configurations)
+        //     .filter(config => Array.isArray(config.transforms)) // Make sure transforms exist
+        //     .flatMap(config => {
+        //         console.log('BRUSHCONFIG', config)
+        //         // Build constraint map from inputContext
+        //         const constraintMap = {};
+        //         Object.keys(config.schema).forEach(channel => {
+        //             const key = `${config.id}_${channel}`;
+        //             constraintMap[channel] = inputContext[key] || [];
+        //         });
+
+        //         const signalPrefix = this.id + '_' + config.id
+        //         // Generate signals for this configuratio
+
+                
+        //         const signals = generateSignalsFromTransforms(
+        //             config.transforms,
+        //             nodeId,
+        //             signalPrefix,
+        //             constraintMap
+        //         );
+        //         console.log('BRUSHCONFIG', signals)
+        //         return signals;
+        //     });
+
+        // console.log('OUTPUT SIGNALS', outputSignals)
 
 
         const xNodeStart = extractAllNodeNames(inputContext['interval_x'].find(constraint => constraint.includes('start')))[0]

--- a/src/components/interactions/drag2.ts
+++ b/src/components/interactions/drag2.ts
@@ -213,6 +213,7 @@ export function generateConfigurationAnchors(id: string, configurationId: string
     } else if (schema.container === 'Range') {
         return createRangeAccessor(id, channel, configurationId);
     } else if (schema.container === 'Data') {
+        console.log('generating dataAnchor', id, configurationId, channel)
         return {
             'value': `${id}_${configurationId}_${channel}`
         }

--- a/src/components/interactions/drag2.ts
+++ b/src/components/interactions/drag2.ts
@@ -261,7 +261,6 @@ export class CombinedDrag extends BaseComponent {
 
     compileComponent(inputContext: CompilationContext): Partial<UnitSpec<Field>> {
         const nodeId = inputContext.nodeId || this.id;
-        console.log('inputContextDRAG', inputContext,nodeId)
         const markName = inputContext['point_markName']?.[0] ? inputContext['point_markName'][0]+"_marks" : '';
         const signal = {
             name: this.id, // base signal

--- a/src/components/interactions/drag2.ts
+++ b/src/components/interactions/drag2.ts
@@ -212,6 +212,10 @@ export function generateConfigurationAnchors(id: string, configurationId: string
         }
     } else if (schema.container === 'Range') {
         return createRangeAccessor(id, channel, configurationId);
+    } else if (schema.container === 'Data') {
+        return {
+            'value': `${id}_${configurationId}_${channel}`
+        }
     }
     return { 'value': '' }
 }
@@ -244,6 +248,7 @@ export class CombinedDrag extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+
                     return generatedAnchor
                 }));
             }

--- a/src/components/marks/circle.ts
+++ b/src/components/marks/circle.ts
@@ -111,7 +111,6 @@ export class Circle extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }

--- a/src/components/marks/circle.ts
+++ b/src/components/marks/circle.ts
@@ -111,6 +111,7 @@ export class Circle extends BaseComponent {
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }

--- a/src/components/marks/line.ts
+++ b/src/components/marks/line.ts
@@ -150,7 +150,7 @@ export class Line extends BaseComponent {
 
         // Generate all signals from configurations
         let generatedSignals = Object.values(this.configurations)
-            .filter(config => Array.isArray(config.transforms)) // Make sure transforms exist
+            // .filter(config => Array.isArray(config.transforms)) // Make sure transforms exist
             .flatMap(config => {
                 // Build constraint map from inputContext
                 const constraintMap = {};

--- a/src/components/marks/rect.ts
+++ b/src/components/marks/rect.ts
@@ -122,8 +122,6 @@ export class Rect extends BaseComponent {
                 );
             });
 
-            console.log('outputSignalsRECT', outputSignals)
-
 
             const internalSignals = [...this.anchors.keys()]
             .filter(key => key.endsWith('_internal'))

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -211,28 +211,35 @@ export class Text extends BaseComponent {
             ],
             "data":{"values":[{}]}, //TODO FIX
             name: `${this.id}_position_markName`,
-            "layer": [
-                 {
-                    mark: {
-                        type: "text",
-                        "size": 20,
-                        "align": "left",
-                        "color": "white",
-                        "stroke": "white",
-                        "strokeWidth": 3,
-                        "opacity": 1//.5
-                    },
-                },
-                {
-                    mark: {
+            // "layer": [
+            //      {
+            //         mark: {
+            //             type: "text",
+            //             "size": 20,
+            //             "align": "left",
+            //             "color": "white",
+            //             "stroke": "white",
+            //             "strokeWidth": 3,
+            //             "opacity": 1//.5
+            //         },
+            //     },
+            //     {
+            //         mark: {
+            //             type: "text",
+            //             "size": 20,
+            //             "align": "left",
+            //             "color": "firebrick",
+            //         },
+            //     },
+               
+            // ]
+            // 
+            mark: {
                         type: "text",
                         "size": 20,
                         "align": "left",
                         "color": "firebrick",
                     },
-                },
-               
-            ],
            
             "encoding": {
                 "x": {

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -49,6 +49,7 @@ const configurations = [{
             "valueType": "Categorical",
             // "interactive": true
         },
+       
     },
     "transforms": [
         { "name": "x", "channel": "x", "value": "PARENT_ID.x" },
@@ -126,12 +127,16 @@ export class Text extends BaseComponent {
                 const keyName = config.id + '_' + key
                 this.schema[keyName] = schemaValue;
 
+                console.log('generating TEXTanchor for ', keyName, schemaValue)
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
+                    
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
+                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }
+            console.log('this.anchors', this.anchors)
       
         });
 
@@ -208,6 +213,7 @@ export class Text extends BaseComponent {
              
             ).flat();
        
+        let dataAccessor = inputContext?.position_data?.[0]? {'name':inputContext?.position_data?.[0]} : {"values":[{}]};
 
         return {
             params: [
@@ -218,7 +224,7 @@ export class Text extends BaseComponent {
                 ...outputSignals,
                 ...internalSignals
             ],
-            "data":inputContext.position_data[0] + "_data" || {"values":[{}]}, //TODO FIX
+            "data": dataAccessor,
             name: `${this.id}_position_markName`,
             // "layer": [
             //      {
@@ -259,7 +265,7 @@ export class Text extends BaseComponent {
                 },
                 "text": {
                     // "value": { "expr": `${this.id}_position_text` },
-                    "value": this.baseConfig.text
+                    "value": "tester"
                 },
             }
         }

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -34,11 +34,16 @@ const configurations = [{
             "valueType": "Numeric",
             // "interactive": true
         },
-        // "text": {
-        //     "container": "Scalar",
-        //     "valueType": "Categorical",
-        //     // "interactive": true
-        // },
+        "text": {
+            "container": "Scalar",
+            "valueType": "Categorical",
+            // "interactive": true
+        },
+        "data": {
+            "container": "Data",
+            "valueType": "Data",
+            // "interactive": true
+        },
         "markName": {
             "container": "Scalar",
             "valueType": "Categorical",
@@ -51,6 +56,8 @@ const configurations = [{
         // { "name": "text", "channel": "text", "value": "PARENT_ID.text" }
     ]
 }];
+
+
 /*
 {
     'id': 'appearance',

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -48,7 +48,7 @@ const configurations = [{
             "container": "Scalar",
             "valueType": "Categorical",
             // "interactive": true
-        }
+        },
     },
     "transforms": [
         { "name": "x", "channel": "x", "value": "PARENT_ID.x" },
@@ -161,6 +161,8 @@ export class Text extends BaseComponent {
             value: textBaseContext
         };
 
+        
+
         // // TODO handle missing key/anchors
         // const outputSignals = Object.keys(this.schema).map(key =>
         //     generateSignalFromAnchor(inputContext[key] || [], key, this.id, nodeId, this.schema[key].container)
@@ -216,7 +218,7 @@ export class Text extends BaseComponent {
                 ...outputSignals,
                 ...internalSignals
             ],
-            "data":{"values":[{}]}, //TODO FIX
+            "data":inputContext.position_data[0] + "_data" || {"values":[{}]}, //TODO FIX
             name: `${this.id}_position_markName`,
             // "layer": [
             //      {

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -129,7 +129,6 @@ export class Text extends BaseComponent {
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
 
                     const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-                    console.log('generatedAnchor', generatedAnchor)
                     return generatedAnchor
                 }));
             }
@@ -140,7 +139,6 @@ export class Text extends BaseComponent {
 
     compileComponent(inputContext: compilationContext): Partial<UnitSpec<Field>> {
         const nodeId = inputContext.nodeId || this.id;
-        console.log('compiling text', this.id, inputContext)
 
 
         // Base text signal
@@ -179,11 +177,9 @@ export class Text extends BaseComponent {
                             'channel': channel,
                             'value': firstConstraint
                         });
-                        console.log('ADDING TRANSFORM', transforms)
                     }
                 }
 
-                console.log('CONSTRAINT MAP', constraintMap)
                
 
 
@@ -197,25 +193,21 @@ export class Text extends BaseComponent {
                     constraintMap
                 );
             });
-            console.log('TEXT OUTPUT SIGNALS', outputSignals)
 
         // Check if there's a signal with name ending with 'position_text'
         const hasPositionTextSignal = outputSignals.some(signal => 
             signal.name && signal.name.endsWith('_position_text')
         );
 
-        console.log('HAS POSITION TEXT SIGNAL', hasPositionTextSignal,constraintMap, outputSignals.find(s => s.name === `${this.id}_position_text`))
         
         // If no position_text signal exists, add one
         if (!hasPositionTextSignal) {
-            console.log('ADDING POSITION TEXT SIGNAL', `${this.id}_position_text`)
             outputSignals.push({
                 "name": `${this.id}_position_text`,
                 "value": "SAMPLEtext"
             });
         }
 
-        console.log('OUTPUT SIGNALS', outputSignals)
 
 
         const internalSignals = [...this.anchors.keys()]
@@ -237,7 +229,6 @@ export class Text extends BaseComponent {
 
         let dataAccessor = inputContext?.position_data?.[0] ? { 'name': inputContext?.position_data?.[0] } : { "values": [{}] };
 
-        console.log('textfsdljk', getEncodingValue('text', constraintMap, this.id), 'x')
         return {
             params: [
                 {

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -156,8 +156,9 @@ export class Text extends BaseComponent {
             constraintMap[channel] = inputContext[key] || inputContext[channel] || [];
         });
 
+        const configs = JSON.parse(JSON.stringify(this.configurations))
         // Generate all signals from configurations
-        const outputSignals = Object.values(this.configurations)
+        const outputSignals = Object.values(configs)
             .flatMap(config => {
                 let transforms = config.transforms || [];
 
@@ -196,14 +197,18 @@ export class Text extends BaseComponent {
                     constraintMap
                 );
             });
+            console.log('TEXT OUTPUT SIGNALS', outputSignals)
 
         // Check if there's a signal with name ending with 'position_text'
         const hasPositionTextSignal = outputSignals.some(signal => 
             signal.name && signal.name.endsWith('_position_text')
         );
+
+        console.log('HAS POSITION TEXT SIGNAL', hasPositionTextSignal,constraintMap, outputSignals.find(s => s.name === `${this.id}_position_text`))
         
         // If no position_text signal exists, add one
         if (!hasPositionTextSignal) {
+            console.log('ADDING POSITION TEXT SIGNAL', `${this.id}_position_text`)
             outputSignals.push({
                 "name": `${this.id}_position_text`,
                 "value": "SAMPLEtext"

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -265,7 +265,7 @@ export class Text extends BaseComponent {
                 },
                 "text": {
                     // "value": { "expr": `${this.id}_position_text` },
-                    "value": "tester"
+                    "value": {"expr":`datum.count`}
                 },
             }
         }

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -211,12 +211,29 @@ export class Text extends BaseComponent {
             ],
             "data":{"values":[{}]}, //TODO FIX
             name: `${this.id}_position_markName`,
-            mark: {
-                type: "text",
-                "size": 20,
-                "align": "left",
-                "color": "firebrick",
-            },
+            "layer": [
+                 {
+                    mark: {
+                        type: "text",
+                        "size": 20,
+                        "align": "left",
+                        "color": "white",
+                        "stroke": "white",
+                        "strokeWidth": 3,
+                        "opacity": 1//.5
+                    },
+                },
+                {
+                    mark: {
+                        type: "text",
+                        "size": 20,
+                        "align": "left",
+                        "color": "firebrick",
+                    },
+                },
+               
+            ],
+           
             "encoding": {
                 "x": {
                     "value": { "expr": `${this.id}_position_x` },

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -113,11 +113,7 @@ export class Text extends BaseComponent {
 
         // Set up the main schema from configurations
         this.schema = {};
-        // Object.values(this.configurations).forEach(config => {
-        //     Object.entries(config.schema).forEach(([key, value]) => {
-        //         this.schema[key] = value as SchemaType;
-        //     });
-        // });
+ 
 
         configurations.forEach(config => {
             this.configurations[config.id] = config
@@ -127,7 +123,6 @@ export class Text extends BaseComponent {
                 const keyName = config.id + '_' + key
                 this.schema[keyName] = schemaValue;
 
-                console.log('generating TEXTanchor for ', keyName, schemaValue)
 
                 this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
                     
@@ -136,23 +131,9 @@ export class Text extends BaseComponent {
                     return generatedAnchor
                 }));
             }
-            console.log('this.anchors', this.anchors)
       
         });
 
-        // // Create anchors for each schema item
-        // Object.keys(this.schema).forEach(key => {
-        //     const schemaValue = schema[key];
-        //     const keyName = config.id + '_' + key
-        //     console.log('creating anchor for ', keyName)
-        //     console.log('setting schema', keyName, schemaValue)
-        //     this.schema[keyName] = schemaValue;
-        //     this.anchors.set(keyName, this.createAnchorProxy({ [keyName]: schemaValue }, keyName, () => {
-        //         const generatedAnchor = generateConfigurationAnchors(this.id, config.id, key, schemaValue)
-        //         console.log('generatedAnchor', generatedAnchor)
-        //         return generatedAnchor
-        //     }));
-        // });
     }
 
     compileComponent(inputContext: compilationContext): Partial<UnitSpec<Field>> {
@@ -165,13 +146,6 @@ export class Text extends BaseComponent {
             name: this.id,
             value: textBaseContext
         };
-
-        
-
-        // // TODO handle missing key/anchors
-        // const outputSignals = Object.keys(this.schema).map(key =>
-        //     generateSignalFromAnchor(inputContext[key] || [], key, this.id, nodeId, this.schema[key].container)
-        // ).flat();
 
         // Generate all signals from configurations
         const outputSignals = Object.values(this.configurations)
@@ -226,29 +200,7 @@ export class Text extends BaseComponent {
             ],
             "data": dataAccessor,
             name: `${this.id}_position_markName`,
-            // "layer": [
-            //      {
-            //         mark: {
-            //             type: "text",
-            //             "size": 20,
-            //             "align": "left",
-            //             "color": "white",
-            //             "stroke": "white",
-            //             "strokeWidth": 3,
-            //             "opacity": 1//.5
-            //         },
-            //     },
-            //     {
-            //         mark: {
-            //             type: "text",
-            //             "size": 20,
-            //             "align": "left",
-            //             "color": "firebrick",
-            //         },
-            //     },
-               
-            // ]
-            // 
+           
             mark: {
                         type: "text",
                         "size": 20,

--- a/src/components/marks/text.ts
+++ b/src/components/marks/text.ts
@@ -55,6 +55,7 @@ const configurations = [{
     "transforms": [
         { "name": "x", "channel": "x", "value": "PARENT_ID.x" },
         { "name": "y", "channel": "y", "value": "PARENT_ID.y" },
+
         // { "name": "text", "channel": "text", "value": "PARENT_ID.text" }
     ]
 }];
@@ -166,11 +167,9 @@ export class Text extends BaseComponent {
                     const key = `${config.id}_${channel}`;
                     constraintMap[channel] = inputContext[key] || inputContext[channel] || [];
                 });
-                console.log('CONSTRAINT MAP', constraintMap)
 
                 // Create a transform for each item in the constraint map
                 for (const channel in constraintMap) {
-                    console.log('CHANNEL', channel, constraintMap)
                     if (constraintMap[channel] && constraintMap[channel].length > 0 && !transforms.some(t => t.channel === channel)) {
                         // Use the first constraint value as the transform value
                         const firstConstraint = constraintMap[channel][0];
@@ -183,6 +182,9 @@ export class Text extends BaseComponent {
                     }
                 }
 
+                console.log('CONSTRAINT MAP', constraintMap)
+               
+
 
                 const signalPrefix = this.id + '_' + config.id;
 
@@ -194,6 +196,19 @@ export class Text extends BaseComponent {
                     constraintMap
                 );
             });
+
+        // Check if there's a signal with name ending with 'position_text'
+        const hasPositionTextSignal = outputSignals.some(signal => 
+            signal.name && signal.name.endsWith('_position_text')
+        );
+        
+        // If no position_text signal exists, add one
+        if (!hasPositionTextSignal) {
+            outputSignals.push({
+                "name": `${this.id}_position_text`,
+                "value": "SAMPLEtext"
+            });
+        }
 
         console.log('OUTPUT SIGNALS', outputSignals)
 

--- a/src/components/signalFactory.ts
+++ b/src/components/signalFactory.ts
@@ -1,0 +1,113 @@
+
+
+// Signal types
+export interface VegaSignalSpec {
+  name: string;
+  value: any;
+  on: VegaSignalUpdate[];
+}
+
+export interface VegaSignalUpdate {
+  events: any;
+  update: string;
+}
+
+// Constraint types
+export interface Constraint {
+  type: 'expression' | 'absolute' | 'relative';
+  value: string | number;
+  source?: string;
+}
+
+export interface RangeConstraint {
+  start?: Constraint;
+  stop?: Constraint;
+}
+
+// Schema types with clear definitions
+export enum SchemaContainerType {
+  Scalar = 'Scalar',
+  Range = 'Range',
+  Set = 'Set'
+}
+
+export interface ChannelSchema {
+  container: SchemaContainerType;
+  valueType: 'Numeric' | 'Categorical' | 'Boolean';
+  interactive?: boolean;
+}
+
+
+/**
+ * Manages creation and updating of Vega signals in a structured way
+ */
+class SignalManager {
+    private readonly componentId: string;
+    
+    constructor(componentId: string) {
+      this.componentId = componentId;
+    }
+    
+    /**
+     * Creates a scalar signal configuration
+     */
+    createScalarSignal(
+      channelName: string, 
+      constraints: Constraint[] = [],
+      sourceComponentId?: string
+    ): VegaSignalSpec {
+      const signalName = this.formatSignalName(channelName);
+      
+      // Create base signal spec
+      const signal: VegaSignalSpec = {
+        name: signalName,
+        value: null,
+        on: []
+      };
+      
+      // Add source component update if provided
+      if (sourceComponentId) {
+        signal.on.push({
+          events: { signal: sourceComponentId },
+          update: `${sourceComponentId}.${channelName}`
+        });
+      }
+      
+      // Add constraints as update rules
+      this.addConstraintsToSignal(signal, constraints);
+      
+      return signal;
+    }
+    
+    /**
+     * Creates a range signal (with start and stop values)
+     */
+    createRangeSignal(
+      channelName: string,
+      constraints: RangeConstraint[] = [],
+      sourceComponentId?: string
+    ): VegaSignalSpec[] {
+      const startName = this.formatSignalName(`${channelName}_start`);
+      const stopName = this.formatSignalName(`${channelName}_stop`);
+      
+      // Create both signals with proper references
+      // [implementation details]
+      
+      return [startSignal, stopSignal];
+    }
+    
+    /**
+     * Format a signal name consistently
+     */
+    formatSignalName(channelName: string): string {
+      return `${this.componentId}_${channelName}`;
+    }
+    
+    /**
+     * Add constraints to a signal specification
+     */
+    private addConstraintsToSignal(signal: VegaSignalSpec, constraints: Constraint[]): void {
+      // Process constraints in a clear, structured way
+      // [implementation details]
+    }
+  }

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -239,6 +239,10 @@ interface Transform {
     return transforms
       .map(transform => {
         const channel = transform.channel;
+        if(channel ==='data'){
+            console.log("MAKINGDATA",parentId,transform,constraints)
+            return []
+        }
         const outputName = `${outputPrefix}_${transform.name || channel}`;
         
         const signal = generateSignal({

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -240,7 +240,6 @@ interface Transform {
       .map(transform => {
         const channel = transform.channel;
         if(channel ==='data'){
-            console.log("MAKINGDATA",parentId,transform,constraints)
             return []
         }
         const outputName = `${outputPrefix}_${transform.name || channel}`;
@@ -251,7 +250,6 @@ interface Transform {
           output: outputName,
           constraints: constraints[channel] || [],
         });
-        console.log('SIGNAL', signal)
         return signal
       })
       .filter(signal => signal !== null); // Remove any nulls from skipped signals

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -251,6 +251,7 @@ interface Transform {
           output: outputName,
           constraints: constraints[channel] || [],
         });
+        console.log('SIGNAL', signal)
         return signal
       })
       .filter(signal => signal !== null); // Remove any nulls from skipped signals

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -1,0 +1,88 @@
+import { BaseComponent } from 'components/base';
+import { BindingManager } from '../binding/BindingManager';
+
+// Get reference to the singleton binding manager
+const bindingManager = BindingManager.getInstance();
+
+/**
+ * Creates a component factory that works in two ways:
+ * 1. Called as constructor to create a new component
+ * 2. Accessed as object to get properties from most recent instance
+ */
+export function createComponentFactory<T>(
+  ComponentClass: new (...args: any[]) => T,
+): any {
+  // Create the factory function
+  const factory = function(...args: any[]): T {
+    // Create a new instance
+    const instance = new ComponentClass(...args);
+    return instance;
+  };
+
+  // Create a proxy to intercept property access
+  return new Proxy(factory, {
+    // Handle property access (like brush.data)
+    get(target, prop, receiver) {
+        console.log('getting prop', prop)
+      // If accessing a property on the factory function itself
+      if (prop in target) {
+        return Reflect.get(target, prop, receiver);
+      }
+      
+      // Get the component type from the constructor name
+      const componentType = ComponentClass.name.toLowerCase();
+
+      function cleanComponentType(componentType: string): string {
+        return componentType.replace(/constructor/g, '').trim();
+      }
+      
+      // Otherwise, find the most recent instance of this component type
+      const recentInstance = findMostRecentComponentByType(cleanComponentType(componentType));
+      
+      if (recentInstance && prop in recentInstance) {
+        return recentInstance[prop as keyof T];
+      }
+      
+      // Fallback for undefined properties
+      return undefined;
+    }
+  });
+}
+
+/**
+ * Find the most recently created component of a given type using the binding manager
+ */
+function findMostRecentComponentByType(componentType: string): BaseComponent | null {
+  // Get all nodes from the binding manager
+  const allNodes = bindingManager.getComponents();
+  
+  // Filter nodes by component type and sort by ID number to get most recent
+  const matchingNodes = Array.from(allNodes.values())
+    .filter(node => {
+      // Check if the node ID matches the pattern node_{type}_{number}
+      // or just node_{number} and we need to check the actual component type
+      const idMatch = node.id.match(/^node_(\w+)_(\d+)$/) || node.id.match(/^node_(\d+)$/);
+      
+      if (!idMatch) return false;
+      
+      // If the ID includes the component type, check if it matches
+      if (idMatch[1] && isNaN(Number(idMatch[1]))) {
+        return idMatch[1].toLowerCase() === componentType.toLowerCase();
+      }
+      
+      // Otherwise check the actual component type
+      return node.constructor.name.toLowerCase() === componentType.toLowerCase();
+    })
+    .sort((a, b) => {
+      // Extract node numbers to sort by most recent (highest number)
+      const aMatch = a.id.match(/(\d+)$/);
+      const bMatch = b.id.match(/(\d+)$/);
+      
+      if (!aMatch || !bMatch) return 0;
+      
+      return parseInt(bMatch[1]) - parseInt(aMatch[1]);
+    });
+  
+  // Return the most recent one (first after sorting)
+  return matchingNodes.length > 0 ? matchingNodes[0] : null;
+}

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -32,6 +32,7 @@ export function createComponentFactory<T>(
     //hmm might not resolve for grid?
     LazyBindingRegistry.resolve(componentType, instance as BaseComponent);
 
+    console.log('resolved', instance, instance.bindingManager.getBindings())
     return instance;
   };
 

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -23,11 +23,6 @@ export function createComponentFactory<T>(
     const componentType = cleanComponentType(ComponentClass.name.toLowerCase());
 
 
-
-    if(componentType.includes('brush')){
-        console.log("",instance)
-        // instance = instance.brush;
-    }
     //hmm might not resolve for grid?
     LazyBindingRegistry.resolve(componentType, instance as BaseComponent);
 
@@ -47,7 +42,6 @@ export function createComponentFactory<T>(
       const componentType = cleanComponentType(ComponentClass.name.toLowerCase());
 
     
-      console.log('getting ', componentType, prop)
     
       // Otherwise, find the most recent instance of this component type
       const recentInstance = findMostRecentComponentByType(componentType);

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -23,7 +23,6 @@ export function createComponentFactory<T>(
   return new Proxy(factory, {
     // Handle property access (like brush.data)
     get(target, prop, receiver) {
-        console.log('getting prop', prop)
       // If accessing a property on the factory function itself
       if (prop in target) {
         return Reflect.get(target, prop, receiver);

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -23,16 +23,14 @@ export function createComponentFactory<T>(
     const componentType = cleanComponentType(ComponentClass.name.toLowerCase());
 
 
-    console.log("RESOLVINGYOURNEW",ComponentClass.name, instance, LazyBindingRegistry)
 
     if(componentType.includes('brush')){
-        console.log("RESOLVINGBRUSH",instance)
+        console.log("",instance)
         // instance = instance.brush;
     }
     //hmm might not resolve for grid?
     LazyBindingRegistry.resolve(componentType, instance as BaseComponent);
 
-    console.log('resolved', instance, instance.bindingManager.getBindings())
     return instance;
   };
 

--- a/src/factories/ComponentFactory.ts
+++ b/src/factories/ComponentFactory.ts
@@ -19,12 +19,18 @@ export function createComponentFactory<T>(
   // Create the factory function
   const factory = function(...args: any[]): T {
     // Create a new instance
-    const instance = new ComponentClass(...args);
+    let instance = new ComponentClass(...args);
+    const componentType = cleanComponentType(ComponentClass.name.toLowerCase());
 
 
     console.log("RESOLVINGYOURNEW",ComponentClass.name, instance, LazyBindingRegistry)
+
+    if(componentType.includes('brush')){
+        console.log("RESOLVINGBRUSH",instance)
+        // instance = instance.brush;
+    }
     //hmm might not resolve for grid?
-    LazyBindingRegistry.resolve(cleanComponentType(ComponentClass.name), instance as BaseComponent);
+    LazyBindingRegistry.resolve(componentType, instance as BaseComponent);
 
     return instance;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,8 +24,12 @@ const drag = createComponentFactory(CombinedDrag);
 const rect = createComponentFactory(Rect);
 const line = createComponentFactory(Line);
 const click = createComponentFactory(Click);
+<<<<<<< HEAD
 // const grid = createComponentFactory(Grid);
 const text = createComponentFactory(Text);
+=======
+const grid = createComponentFactory(Grid); 
+>>>>>>> 331999a (set up brush data accessor)
 
 
 export const all = {
@@ -37,10 +41,14 @@ export const all = {
   piechart: (config:any)=> new PieChart(config),
   circle: (config:any)=> new Circle(config),
   drag: drag,
-  brush: brush,
+  Brush: brush,
   rect: rect,
   line: line,
   click: click,
+<<<<<<< HEAD
   Grid: (config:any)=> new Grid(config),
   text: text
+=======
+  Grid: grid,
+>>>>>>> 331999a (set up brush data accessor)
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,20 @@ export { Circle } from './components/marks';
 import { Scatterplot, Histogram, LinePlot, BarChart, Heatmap, PieChart } from './components/charts';
 import { Circle, Line, Text,Rect } from './components/marks';
 import { CombinedDrag, Click } from './components/interactions';  
-import { Grid, BrushConstructor as Brush } from './components/interactions/Instruments/';
+import { Grid, BrushConstructor, Brush } from './components/interactions/Instruments/';
+import { Rect } from './components/marks/rect';
+import { createComponentFactory } from './factories/ComponentFactory';
+
+
+const brush = createComponentFactory(BrushConstructor);
+const drag = createComponentFactory(CombinedDrag);
+const rect = createComponentFactory(Rect);
+const line = createComponentFactory(Line);
+const click = createComponentFactory(Click);
+// const grid = createComponentFactory(Grid);
+const text = createComponentFactory(Text);
+
+
 export const all = {
   scatterplot: (config: any) => new Scatterplot(config),
   histogram: (config: any) => new Histogram(config),
@@ -24,11 +37,11 @@ export const all = {
   heatmap: (config: any) => new Heatmap(config),
   piechart: (config:any)=> new PieChart(config),
   circle: (config:any)=> new Circle(config),
-  drag: (config:any)=> new CombinedDrag(config),
-  brush: (config:any)=> new Brush(config),
-  rect: (config:any)=> new Rect(config),
-  line: (config:any)=> new Line(config),
-  click: (config:any)=> new Click(config),
+  drag: drag,
+  brush: brush,
+  rect: rect,
+  line: line,
+  click: click,
   Grid: (config:any)=> new Grid(config),
-  text: (config:any)=> new Text(config),
+  text: text
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,12 +24,8 @@ const drag = createComponentFactory(CombinedDrag);
 const rect = createComponentFactory(Rect);
 const line = createComponentFactory(Line);
 const click = createComponentFactory(Click);
-<<<<<<< HEAD
 // const grid = createComponentFactory(Grid);
 const text = createComponentFactory(Text);
-=======
-const grid = createComponentFactory(Grid); 
->>>>>>> 331999a (set up brush data accessor)
 
 
 export const all = {
@@ -45,10 +41,6 @@ export const all = {
   rect: rect,
   line: line,
   click: click,
-<<<<<<< HEAD
   Grid: (config:any)=> new Grid(config),
   text: text
-=======
-  Grid: grid,
->>>>>>> 331999a (set up brush data accessor)
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,6 @@ import { Scatterplot, Histogram, LinePlot, BarChart, Heatmap, PieChart } from '.
 import { Circle, Line, Text,Rect } from './components/marks';
 import { CombinedDrag, Click } from './components/interactions';  
 import { Grid, BrushConstructor, Brush } from './components/interactions/Instruments/';
-import { Rect } from './components/marks/rect';
 import { createComponentFactory } from './factories/ComponentFactory';
 
 

--- a/src/types/anchors.ts
+++ b/src/types/anchors.ts
@@ -114,6 +114,7 @@ export type SetValue = {
 
   export type DataValue = {
     data: DataAccessor; // maps to the expression for the value
+    field: string; // maps to the expression for the value
   }
   
 

--- a/src/types/anchors.ts
+++ b/src/types/anchors.ts
@@ -108,16 +108,22 @@ export type SetValue = {
   values: Record<string, SetValue | ScalarValue | RangeValue>; // maps to the expression for the value
 }
 
-export type AbsoluteValue = {
-  absoluteValue: string; // maps to the expression for the value
-}
+  export type AbsoluteValue = {
+    absoluteValue: string; // maps to the expression for the value
+  }
+
+  export type DataValue = {
+    data: DataAccessor; // maps to the expression for the value
+  }
+  
+
 
 export type RangeValue = {
   start: string; // maps to the expression for the value
   stop: string; // maps to the expression for the value
 }
 
-export type SchemaValue = SetValue | ScalarValue | RangeValue | AbsoluteValue;
+export type SchemaValue = SetValue | ScalarValue | RangeValue | AbsoluteValue | DataValue;
 
 // {X:X<range>}
 
@@ -160,6 +166,8 @@ export enum AnchorType {
   SELECTION = 'selection',
   FILTER = 'filter',
   
+  // Data related
+  DATA_TRANSFORMS = 'dataTransforms', 
   // Misc
   OTHER = 'other'
 }
@@ -169,6 +177,7 @@ export enum AnchorType {
   
 
 import { NumericEncodingConstraint,CategoricalEncodingConstraint } from './constraints';
+import { DataAccessor } from 'components/DataAccessor';
 
 // when x is passed down to a component, then scale becomes the encoding constraint (adds constraint + initial value (middle))
 //

--- a/src/types/anchors.ts
+++ b/src/types/anchors.ts
@@ -169,6 +169,8 @@ export enum AnchorType {
   
   // Data related
   DATA_TRANSFORMS = 'dataTransforms', 
+
+  TEXT = 'text',
   // Misc
   OTHER = 'other'
 }

--- a/src/utils/anchorGeneration/rectAnchors.ts
+++ b/src/utils/anchorGeneration/rectAnchors.ts
@@ -12,7 +12,9 @@ export function getChannelFromEncoding(encoding: string): ChannelType {
         "y2": "y",
         "color": "color",
         "size": "size",
-        "shape": "shape"    
+        "shape": "shape",
+        "text": "text",
+        "data": "data"
     }
     
     return channelMap[encoding]

--- a/src/utils/anchorGeneration/rectAnchors.ts
+++ b/src/utils/anchorGeneration/rectAnchors.ts
@@ -1,22 +1,21 @@
 import { createAnchorProxy } from "../../utils/anchorProxy";
 import { BaseComponent } from "../../components/base";
-import {  AnchorOrGroupSchema, ChannelType } from "../../types/anchors";
-export function getChannelFromEncoding(encoding: string): ChannelType {
+import {  AnchorOrGroupSchema, AnchorType, ChannelType } from "../../types/anchors";
+export function getGenericAnchorTypeFromId(encoding: string): AnchorType {
 
-    const channelMap: Record<string, ChannelType> = {
-        "x": "x",
-        "y": "y",
-        "x1": "x",
-        "y1": "y",
-        "x2": "x",
-        "y2": "y",
-        "color": "color",
-        "size": "size",
-        "shape": "shape",
-        "text": "text",
-        "data": "data"
+    const channelMap: Record<string, AnchorType> = {
+        "x": AnchorType.X,
+        "y": AnchorType.Y,
+        "x1": AnchorType.X,
+        "y1": AnchorType.Y,
+        "x2": AnchorType.X,
+        "y2": AnchorType.Y,
+        "color": AnchorType.COLOR,
+        "size": AnchorType.SIZE,
+        "shape": AnchorType.SHAPE,
+        "text": AnchorType.TEXT,
+        "data": AnchorType.DATA
     }
-    
     return channelMap[encoding]
 }
 
@@ -37,7 +36,7 @@ export function generateRectAnchors(component: BaseComponent): Map<string, Ancho
         anchors.set(coord, {
             id: coord,
             type: 'encoding',
-            channel: getChannelFromEncoding(coord),
+            channel: getGenericAnchorTypeFromId(coord),
             interactive: false
         });
     });

--- a/src/utils/encodingHelpers.ts
+++ b/src/utils/encodingHelpers.ts
@@ -1,0 +1,15 @@
+export function getEncodingValue(
+    channel: string,
+    constraintMap: Record<string, any>,
+    componentId: string
+): { expr: string } {
+    const constraint = constraintMap[channel]?.[0];
+    
+    // If constraint exists and contains 'datum[', use it directly
+    if (constraint && constraint.includes('datum[')) {
+        return { expr: constraint };
+    }
+    
+    // Otherwise, use the standard component-based access
+    return { expr: `${componentId}_position_${channel}` };
+} 


### PR DESCRIPTION
This PR enables new functionality for creating data transforms in-line. 

Now, one can reference data directly like vgx.brush.data.count(), and get the count to appear as text. 

This also includes some changes to how text is rendered and introduces a new LazyComponent, that can be used whenever you want to reference a component before initialization (often times to add a new edge from above an ancestor and not a direct parent. 

![2025-03-22 12 54 20](https://github.com/user-attachments/assets/eeb4101c-53df-45a5-a8db-b0e1edc60382)
